### PR TITLE
JSON field name inconsistencies

### DIFF
--- a/API.md
+++ b/API.md
@@ -30,17 +30,17 @@ timeline.on(event_name, function(data) {
  
  `change` _when the current slide changes_
 
-* uniqueid: string, id of the new current slide
+* unique_id: string, id of the new current slide
 
 `color_change` _when background of current slide changes_
 
-* uniqueid: string, id of the new current slide
+* unique_id: string, id of the new current slide
 
 `dataloaded` _after data has been loaded_
 
 `hash_updated` _when the hashbookmack in the url bar is updated_
 
-* uniqueid:  string, id of the new current slide
+* unique_id:  string, id of the new current slide
 * hashbookmark: string, the hash
 
 `loaded` _after story slider and time navigator have been loaded_
@@ -58,7 +58,7 @@ timeline.on(event_name, function(data) {
 
 `removed` _after slide has been removed_
 
-* uniqueid: string, the id of the modified slide
+* unique_id: string, the id of the modified slide
 
 `nav_next` fires when next button is clicked
 
@@ -140,7 +140,7 @@ timeline.on(event_name, function(data) {
         "headline":     <string>,
         "text":         <string>
     },
-    "uniqueid":         <string>    // optional
+    "unique_id":         <string>    // optional
 };
 ```
 

--- a/API_TEST.html
+++ b/API_TEST.html
@@ -142,7 +142,7 @@ html, body {
                 "headline":     $('#headline').val().trim() || "",
                 "text":         $('#text').val().trim() || ""
             },
-            "uniqueid":         ""
+            "unique_id":         ""
         };
         
         timeline.add(d);
@@ -225,7 +225,7 @@ html, body {
         var slides = timeline.config.slides;
         var html = '';      
         for(var i = 0, id; i < slides.length; i++) {
-            id = slides[i].uniqueid;
+            id = slides[i].unique_id;
             html += '<option value="'+id+'">'+id+'</option>';
         }
                 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ The data file should be in JSON format with the following structure
 {
 	"title": {
 			"media": {
-				"caption": 	"",
-				"credit": 	"",
-				"url": 		"url_to_your_media.jpg",
-				"thumb": 	"url_to_your_media.jpg"
+				"caption": 	    "",
+				"credit": 	    "",
+				"url": 		    "url_to_your_media.jpg",
+				"thumbnail":    "url_to_your_media.jpg"
 			},
 			"text": {
 				"headline": "Headline Goes Here",
@@ -115,10 +115,10 @@ The data file should be in JSON format with the following structure
 				"format": 		""
 			},
 			"media": {
-				"caption": 	"",
-				"credit": 	"",
-				"url": 		"url_to_your_media.jpg",
-				"thumb": 	"url_to_your_media.jpg"
+				"caption": 	    "",
+				"credit": 	    "",
+				"url": 		    "url_to_your_media.jpg",
+				"thumbnail": 	"url_to_your_media.jpg"
 			},
 			"text": {
 				"headline": "Headline Goes Here",

--- a/source/js/VCO.Timeline.js
+++ b/source/js/VCO.Timeline.js
@@ -250,7 +250,7 @@ VCO.Timeline = VCO.Class.extend({
 			this.current_id = id;
 			this._timenav.goToId(this.current_id);
 			this._storyslider.goToId(this.current_id, false, true);
-			this.fire("change", {uniqueid: this.current_id}, this);
+			this.fire("change", {unique_id: this.current_id}, this);
 		}
 	},
   
@@ -258,12 +258,12 @@ VCO.Timeline = VCO.Class.extend({
 	goTo: function(n) {
 		if(this.config.title) {
 			if(n == 0) {
-				this.goToId(this.config.title.uniqueid);
+				this.goToId(this.config.title.unique_id);
 			} else {
-				this.goToId(this.config.events[n - 1].uniqueid);
+				this.goToId(this.config.events[n - 1].unique_id);
 			}
 		} else {
-			this.goToId(this.config.events[n].uniqueid);      
+			this.goToId(this.config.events[n].unique_id);      
 		}
 	},
   
@@ -293,9 +293,9 @@ VCO.Timeline = VCO.Class.extend({
   
 	// Add an event
 	add: function(data) {
-		var uniqueid = this.config.addEvent(data);
+		var unique_id = this.config.addEvent(data);
       
-		var n = this._getEventIndex(uniqueid);
+		var n = this._getEventIndex(unique_id);
 		var d = this.config.events[n];
         
 		this._storyslider.createSlide(d, this.config.title ? n+1 : n);
@@ -304,14 +304,14 @@ VCO.Timeline = VCO.Class.extend({
 		this._timenav.createMarker(d, n);
 		this._timenav._updateDrawTimeline(false); 
         
-		this.fire("added", {uniqueid: uniqueid});
+		this.fire("added", {unique_id: unique_id});
 	},
   
 	// Remove an event
 	remove: function(n) {
 		if(n >= 0  && n < this.config.events.length) {
 			// If removing the current, nav to new one first
-			if(this.config.events[n].uniqueid == this.current_id) {
+			if(this.config.events[n].unique_id == this.current_id) {
 				if(n < this.config.events.length - 1) {
 					this.goTo(n + 1);
 				} else {
@@ -327,7 +327,7 @@ VCO.Timeline = VCO.Class.extend({
 			this._timenav.destroyMarker(n);
 			this._timenav._updateDrawTimeline(false);
          
-			this.fire("removed", {uniqueid: event[0].uniqueid});
+			this.fire("removed", {unique_id: event[0].unique_id});
 		}
 	},
   
@@ -547,7 +547,7 @@ VCO.Timeline = VCO.Class.extend({
 	// Update hashbookmark in the url bar
 	_updateHashBookmark: function(id) {
 		window.location.hash = "#" + "event-" + id.toString();
-		this.fire("hash_updated", {uniqueid:this.current_id, hashbookmark:"#" + "event-" + id.toString()}, this);
+		this.fire("hash_updated", {unique_id:this.current_id, hashbookmark:"#" + "event-" + id.toString()}, this);
 	},
 	
 	/*  Init
@@ -670,7 +670,7 @@ VCO.Timeline = VCO.Class.extend({
 	================================================== */
 	_getEventIndex: function(id) {
 		for(var i = 0; i < this.config.events.length; i++) {
-			if(id == this.config.events[i].uniqueid) {
+			if(id == this.config.events[i].unique_id) {
 				return i;
 			}
 		}
@@ -680,11 +680,11 @@ VCO.Timeline = VCO.Class.extend({
 	/*  Get index of slide by id
 	================================================== */
 	_getSlideIndex: function(id) {
-		if(this.config.title && this.config.title.uniqueid == id) {
+		if(this.config.title && this.config.title.unique_id == id) {
 			return 0;
 		}
 		for(var i = 0; i < this.config.events.length; i++) {
-			if(id == this.config.events[i].uniqueid) {
+			if(id == this.config.events[i].unique_id) {
 				return this.config.title ? i+1 : i;
 			}
 		}
@@ -714,7 +714,7 @@ VCO.Timeline = VCO.Class.extend({
 	},
   
 	_onColorChange: function(e) {
-		this.fire("color_change", {uniqueid:this.current_id}, this);
+		this.fire("color_change", {unique_id:this.current_id}, this);
 		if (e.color || e.image) {
       
 		} else {
@@ -723,23 +723,23 @@ VCO.Timeline = VCO.Class.extend({
 	},
   
 	_onSlideChange: function(e) {
-		if (this.current_id != e.uniqueid) {
-			this.current_id = e.uniqueid;
+		if (this.current_id != e.unique_id) {
+			this.current_id = e.unique_id;
 			this._timenav.goToId(this.current_id);
 			this._onChange(e);
 		}
 	},
   
 	_onTimeNavChange: function(e) {
-		if (this.current_id != e.uniqueid) {
-			this.current_id = e.uniqueid;
+		if (this.current_id != e.unique_id) {
+			this.current_id = e.unique_id;
 			this._storyslider.goToId(this.current_id);
 			this._onChange(e);
 		}
 	},
   
 	_onChange: function(e) {
-		this.fire("change", {uniqueid:this.current_id}, this);
+		this.fire("change", {unique_id:this.current_id}, this);
 		if (this.options.hash_bookmark) {
 			this._updateHashBookmark(this.current_id);
 		}
@@ -747,7 +747,7 @@ VCO.Timeline = VCO.Class.extend({
   
 	_onBackToStart: function(e) {
 		this._storyslider.goTo(0);
-		this.fire("back_to_start", {uniqueid:this.current_id}, this);
+		this.fire("back_to_start", {unique_id:this.current_id}, this);
 	},
   
 	_onZoomIn: function(e) {

--- a/source/js/VCO.Timeline.js
+++ b/source/js/VCO.Timeline.js
@@ -263,50 +263,50 @@ VCO.Timeline = VCO.Class.extend({
 				this.goToId(this.config.events[n - 1].unique_id);
 			}
 		} else {
-			this.goToId(this.config.events[n].unique_id);      
+			this.goToId(this.config.events[n].unique_id);
 		}
 	},
-  
+
 	// Goto first slide
 	goToStart: function() {
 		this.goTo(0);
 	},
-  
+
 	// Goto last slide
 	goToEnd: function() {
 		var _n = this.config.events.length - 1;
 		this.goTo(this.config.title ? _n + 1 : _n);
 	},
-  
+
 	// Goto previous slide
 	goToPrev: function() {
 		this.goTo(this._getSlideIndex(this.current_id) - 1);
 	},
-  
+
 	// Goto next slide
 	goToNext: function() {
 		this.goTo(this._getSlideIndex(this.current_id) + 1);
 	},
-  
+
 	/* Event maniupluation
 	================================================== */
-  
+
 	// Add an event
 	add: function(data) {
 		var unique_id = this.config.addEvent(data);
-      
+
 		var n = this._getEventIndex(unique_id);
 		var d = this.config.events[n];
-        
+
 		this._storyslider.createSlide(d, this.config.title ? n+1 : n);
-		this._storyslider._updateDrawSlides();            
-        
+		this._storyslider._updateDrawSlides();
+
 		this._timenav.createMarker(d, n);
-		this._timenav._updateDrawTimeline(false); 
-        
+		this._timenav._updateDrawTimeline(false);
+
 		this.fire("added", {unique_id: unique_id});
 	},
-  
+
 	// Remove an event
 	remove: function(n) {
 		if(n >= 0  && n < this.config.events.length) {

--- a/source/js/core/VCO.ConfigFactory.js
+++ b/source/js/core/VCO.ConfigFactory.js
@@ -32,7 +32,7 @@
                 caption: item_data.mediacaption || '',
                 credit: item_data.mediacredit || '',
                 url: item_data.media || '',
-                thumb: item_data.mediathumbnail || ''
+                thumbnail: item_data.mediathumbnail || ''
             },
             text: {
                 headline: item_data.headline || '',
@@ -63,7 +63,7 @@
                 caption: item_data.mediacaption || '',
                 credit: item_data.mediacredit || '',
                 url: item_data.media || '',
-                thumb: item_data.mediathumbnail || ''
+                thumbnail: item_data.mediathumbnail || ''
             },
             text: {
                 headline: item_data.headline || '',

--- a/source/js/core/VCO.TimelineConfig.js
+++ b/source/js/core/VCO.TimelineConfig.js
@@ -56,19 +56,19 @@ VCO.TimelineConfig = VCO.Class.extend({
 	/* Add an event and return the unique id 
 	*/
 	addEvent: function(data) {
-		var _id = (this.title) ? this.title.uniqueid : '';
+		var _id = (this.title) ? this.title.unique_id : '';
 		this.events.push(data);
-		this._makeUniqueIdentifiers(_id, this.events); 
+		this._makeunique_identifiers(_id, this.events); 
 		this._processDates(this.events);    
         
-		var uniqueid = this.events[this.events.length - 1].uniqueid;             
+		var unique_id = this.events[this.events.length - 1].unique_id;             
 		VCO.DateUtil.sortByDate(this.events);
-		return uniqueid;
+		return unique_id;
 	},
 
 	_cleanData: function() {
-		var _id = (this.title) ? this.title.uniqueid : '';
-		this._makeUniqueIdentifiers(_id, this.events); 
+		var _id = (this.title) ? this.title.unique_id : '';
+		this._makeunique_identifiers(_id, this.events); 
 		this._processDates(this.events);
 		this._cleanGroups(this.events)          ;
 		VCO.DateUtil.sortByDate(this.events);
@@ -81,26 +81,26 @@ VCO.TimelineConfig = VCO.Class.extend({
 		}
         
 		// Make sure title slide has unique id
-		if(this.title && !('uniqueid' in this.title)) {
-			this.title.uniqueid = '';
+		if(this.title && !('unique_id' in this.title)) {
+			this.title.unique_id = '';
 		}
 	},
 
-	_makeUniqueIdentifiers: function(title_id, array) {
+	_makeunique_identifiers: function(title_id, array) {
 		var used = [title_id];
 		for (var i = 0; i < array.length; i++) {
-			if (array[i].uniqueid && array[i].uniqueid.replace(/\s+/,'').length > 0) {
-				array[i].uniqueid = VCO.Util.slugify(array[i].uniqueid); // enforce valid
-				if (used.indexOf(array[i].uniqueid) != -1) {
-					array[i].uniqueid = '';
+			if (array[i].unique_id && array[i].unique_id.replace(/\s+/,'').length > 0) {
+				array[i].unique_id = VCO.Util.slugify(array[i].unique_id); // enforce valid
+				if (used.indexOf(array[i].unique_id) != -1) {
+					array[i].unique_id = '';
 				} else {
-					used.push(array[i].uniqueid);
+					used.push(array[i].unique_id);
 				}
 			}
 		};
 		if (used.length != (array.length + 1)) {
 			for (var i = 0; i < array.length; i++) {
-				if (!array[i].uniqueid) {
+				if (!array[i].unique_id) {
 					var slug = (array[i].text) ? VCO.Util.slugify(array[i].text.headline) : null;
 					if (!slug) {
 						slug = VCO.Util.unique_ID(6);
@@ -109,7 +109,7 @@ VCO.TimelineConfig = VCO.Class.extend({
 						slug = slug + '-' + i;
 					}
 					used.push(slug);
-					array[i].uniqueid = slug;
+					array[i].unique_id = slug;
 				}
 			}
 		}

--- a/source/js/core/VCO.Util.js
+++ b/source/js/core/VCO.Util.js
@@ -19,8 +19,8 @@ VCO.Util = {
 	
 	setOptions: function (obj, options) {
 		obj.options = VCO.Util.extend({}, obj.options, options);
-		if (obj.options.uniqueid === "") {
-			obj.options.uniqueid = VCO.Util.unique_ID(6);
+		if (obj.options.unique_id === "") {
+			obj.options.unique_id = VCO.Util.unique_ID(6);
 		}
 	},
 	
@@ -28,7 +28,7 @@ VCO.Util = {
 	  return n == parseFloat(n)? !(n%2) : void 0;
 	},
 	
-	findArrayNumberByUniqueID: function(id, array, prop, defaultVal) {
+	findArrayNumberByunique_id: function(id, array, prop, defaultVal) {
 		var _n = defaultVal || 0;
 		
 		for (var i = 0; i < array.length; i++) {
@@ -72,8 +72,8 @@ VCO.Util = {
 	
 	setData: function (obj, data) {
 		obj.data = VCO.Util.extend({}, obj.data, data);
-		if (obj.data.uniqueid === "") {
-			obj.data.uniqueid = VCO.Util.unique_ID(6);
+		if (obj.data.unique_id === "") {
+			obj.data.unique_id = VCO.Util.unique_ID(6);
 		}
 	},
 	

--- a/source/js/map/VCO.Map.js
+++ b/source/js/map/VCO.Map.js
@@ -72,7 +72,7 @@ VCO.Map = VCO.Class.extend({
 	
 		// Data
 		this.data = {
-			uniqueid: 			"",
+			unique_id: 			"",
 			slides: 				[{test:"yes"}, {test:"yes"}, {test:"yes"}]
 		};
 	

--- a/source/js/media/VCO.Media.js
+++ b/source/js/media/VCO.Media.js
@@ -48,7 +48,7 @@ VCO.Media = VCO.Class.extend({
 	
 		// Data
 		this.data = {
-			uniqueid: 			null,
+			unique_id: 			null,
 			url: 				null,
 			credit:				null,
 			caption:			null,
@@ -75,8 +75,8 @@ VCO.Media = VCO.Class.extend({
 		
 		this._el.container = VCO.Dom.create("div", "vco-media");
 		
-		if (this.data.uniqueid) {
-			this._el.container.id = this.data.uniqueid;
+		if (this.data.unique_id) {
+			this._el.container.id = this.data.unique_id;
 		}
 		
 		

--- a/source/js/media/types/VCO.Media.Text.js
+++ b/source/js/media/types/VCO.Media.Text.js
@@ -13,7 +13,7 @@ VCO.Media.Text = VCO.Class.extend({
 	
 	// Data
 	data: {
-		uniqueid: 			"",
+		unique_id: 			"",
 		headline: 			"headline",
 		text: 				"text"
 	},
@@ -33,7 +33,7 @@ VCO.Media.Text = VCO.Class.extend({
 		VCO.Util.mergeData(this.options, options);
 		
 		this._el.container = VCO.Dom.create("div", "vco-text");
-		this._el.container.id = this.data.uniqueid;
+		this._el.container.id = this.data.unique_id;
 		
 		this._initLayout();
 		

--- a/source/js/slider/VCO.Slide.js
+++ b/source/js/slider/VCO.Slide.js
@@ -47,7 +47,7 @@ VCO.Slide = VCO.Class.extend({
 		
 		// Data
 		this.data = {
-			uniqueid: 				null,
+			unique_id: 				null,
 			background: 			null,
 			start_date: 			null,
 			end_date: 				null,
@@ -178,8 +178,8 @@ VCO.Slide = VCO.Class.extend({
 			this._el.container.className = "vco-slide vco-slide-titleslide";
 		}
 		
-		if (this.data.uniqueid) {
-			this._el.container.id 		= this.data.uniqueid;
+		if (this.data.unique_id) {
+			this._el.container.id 		= this.data.unique_id;
 		}
 		this._el.scroll_container 		= VCO.Dom.create("div", "vco-slide-scrollable-container", this._el.container);
 		this._el.content_container		= VCO.Dom.create("div", "vco-slide-content-container", this._el.scroll_container);

--- a/source/js/slider/VCO.StorySlider.js
+++ b/source/js/slider/VCO.StorySlider.js
@@ -129,8 +129,8 @@ VCO.StorySlider = VCO.Class.extend({
 
 	_createSlides: function(array) {
 		for (var i = 0; i < array.length; i++) {
-			if (array[i].uniqueid == "") {
-				array[i].uniqueid = VCO.Util.unique_ID(6, "vco-slide");
+			if (array[i].unique_id == "") {
+				array[i].unique_id = VCO.Util.unique_ID(6, "vco-slide");
 			}
             this._createSlide(array[i], false, -1);
 		}
@@ -150,7 +150,7 @@ VCO.StorySlider = VCO.Class.extend({
     _findSlideIndex: function(n) {
         var _n = n;
 		if (typeof n == 'string' || n instanceof String) {
-			_n = VCO.Util.findArrayNumberByUniqueID(n, this._slides, "uniqueid");
+			_n = VCO.Util.findArrayNumberByunique_id(n, this._slides, "unique_id");
 		}
 		return _n;
     },
@@ -199,7 +199,7 @@ VCO.StorySlider = VCO.Class.extend({
 		}
 		
 		if (n < this._slides.length && n >= 0) {			
-			this.current_id = this._slides[n].data.uniqueid;
+			this.current_id = this._slides[n].data.unique_id;
 
 			// Stop animation
 			if (this.animator) {
@@ -508,7 +508,7 @@ VCO.StorySlider = VCO.Class.extend({
 	
 	_onSlideChange: function(displayupdate) {		
 		if (!displayupdate) {
-			this.fire("change", {uniqueid: this.current_id});
+			this.fire("change", {unique_id: this.current_id});
 		}
 	},
 	

--- a/source/js/timenav/VCO.TimeMarker.js
+++ b/source/js/timenav/VCO.TimeMarker.js
@@ -36,7 +36,7 @@ VCO.TimeMarker = VCO.Class.extend({
 		
 		// Data
 		this.data = {
-			uniqueid: 			"",
+			unique_id: 			"",
 			background: 		null,
 			date: {
 				year:			0,
@@ -222,7 +222,7 @@ VCO.TimeMarker = VCO.Class.extend({
 	/*	Events
 	================================================== */
 	_onMarkerClick: function(e) {
-		this.fire("markerclick", {uniqueid:this.data.uniqueid});
+		this.fire("markerclick", {unique_id:this.data.unique_id});
 	},
 	
 	/*	Private Methods
@@ -231,8 +231,8 @@ VCO.TimeMarker = VCO.Class.extend({
 		//trace(this.data)
 		// Create Layout
 		this._el.container 				= VCO.Dom.create("div", "vco-timemarker");
-		if (this.data.uniqueid) {
-			this._el.container.id 		= this.data.uniqueid + "-marker";
+		if (this.data.unique_id) {
+			this._el.container.id 		= this.data.unique_id + "-marker";
 		}
 		
 		if (this.data.end_date) {

--- a/source/js/timenav/VCO.TimeMarker.js
+++ b/source/js/timenav/VCO.TimeMarker.js
@@ -253,9 +253,9 @@ VCO.TimeMarker = VCO.Class.extend({
 		if (this.data.media) {
 			this._el.media_container	= VCO.Dom.create("div", "vco-timemarker-media-container", this._el.content);
 			
-			if (this.data.media.thumb && this.data.media.thumb != "") {
+			if (this.data.media.thumbnail && this.data.media.thumbnail != "") {
 				this._el.media				= VCO.Dom.create("img", "vco-timemarker-media", this._el.media_container);
-				this._el.media.src			= this.data.media.thumb;
+				this._el.media.src			= this.data.media.thumbnail;
 				
 			} else {
 				var media_type = VCO.MediaType(this.data.media).type;

--- a/source/js/timenav/VCO.TimeNav.js
+++ b/source/js/timenav/VCO.TimeNav.js
@@ -295,7 +295,7 @@ VCO.TimeNav = VCO.Class.extend({
 	_findMarkerIndex: function(n) {	
 	    var _n = -1;
 		if (typeof n == 'string' || n instanceof String) {
-			_n = VCO.Util.findArrayNumberByUniqueID(n, this._markers, "uniqueid", _n);
+			_n = VCO.Util.findArrayNumberByunique_id(n, this._markers, "unique_id", _n);
 		} 
 		return _n;
 	},
@@ -360,7 +360,7 @@ VCO.TimeNav = VCO.Class.extend({
 		}
 		
 		if(n >= 0 && n < this._markers.length) {
-		    this.current_id = this._markers[n].data.uniqueid;
+		    this.current_id = this._markers[n].data.unique_id;
 		} else {
 		    this.current_id = '';
 		}
@@ -386,8 +386,8 @@ VCO.TimeNav = VCO.Class.extend({
 	
 	_onMarkerClick: function(e) {
 		// Go to the clicked marker
-		this.goToId(e.uniqueid);
-		this.fire("change", {uniqueid: e.uniqueid});
+		this.goToId(e.unique_id);
+		this.fire("change", {unique_id: e.unique_id});
 	},
 	
 	_onMouseScroll: function(e) {

--- a/util/convert_json.py
+++ b/util/convert_json.py
@@ -82,7 +82,7 @@ The data file should be in JSON format with the following structure
                     "caption":  "",
                     "credit":   "",
                     "url":      "url_to_your_media.jpg",
-                    "thumb":    "url_to_your_media.jpg"
+                    "thumbnail":    "url_to_your_media.jpg"
                 },
                 "text": {
                     "headline": "Headline Goes Here",

--- a/website/templates/examples/republican/timeline3.json
+++ b/website/templates/examples/republican/timeline3.json
@@ -5,7 +5,7 @@
           "caption": "",
           "credit": "",
           "url": "",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "The Republican Run-Up",
@@ -18,7 +18,7 @@
           "caption": "Rick Santorum at the Iowa State Fair before the Ages Straw Poll.",
           "credit": "<a href=\"http://www.flickr.com/photos/gageskidmore/6057989217/\">Gage Skidmore</a>/Flickr",
           "url": "https://farm7.staticflickr.com/6200/6057989217_3bd755477b.jpg",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "Iowa",
@@ -35,7 +35,7 @@
           "caption": "From Romney's victory speech, directed at Newt Gingrich, former House speaker",
           "credit": "Romney Wins In New Hampshire Republican Primary/New York Times",
           "url": "<blockquote>“In the last few days, we have seen some desperate Republicans join forces with him,” Romney said. “This is such a mistake for our party and for our nation. This country already has a leader who divides us with the bitter politics of envy.”</blockquote>",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "New Hampshire",
@@ -52,7 +52,7 @@
           "caption": "Gingrich addresses supporters after South Carolina victory.",
           "credit": "YouTube.com",
           "url": "https://youtu.be/2n5yakw5jgo",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "South Carolina",
@@ -69,7 +69,7 @@
           "caption": "",
           "credit": "<a href=\"http://www.flickr.com/photos/mittromney/6812048183/\" title=\"Untitled by Mitt Romney, on Flickr\">Mitt Romney</a>/Flickr",
           "url": "//farm8.staticflickr.com/7001/6812048183_316d424f2f.jpg",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "Florida",
@@ -86,7 +86,7 @@
           "caption": "",
           "credit": "Twitter.com",
           "url": "https://twitter.com/#!/MittRomney/status/165994713806155776",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "Nevada",
@@ -103,7 +103,7 @@
           "caption": "",
           "credit": "<a href=\"http://www.flickr.com/photos/20325042@N05/6857070403/\" title=\"_MG_4530 by ernie_tacsik, on Flickr\">ernie_tacsik</a>/Flickr",
           "url": "//farm8.staticflickr.com/7180/6857070403_03901a5026.jpg",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "Missouri, Minnesota, Colorado",
@@ -120,7 +120,7 @@
           "caption": "",
           "credit": "Twitter.com",
           "url": "https://twitter.com/#!/MattWilliams06/status/171385782936932353",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "Maine",
@@ -137,7 +137,7 @@
           "caption": "",
           "credit": "YouTube",
           "url": "https://youtu.be/IoFfUg8YtC0",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "Arizona debates",
@@ -154,7 +154,7 @@
           "caption": "",
           "credit": "YouTube",
           "url": "https://youtu.be/8-fU-knxT0U",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "Gingrich refuses to get personal during South Carolina debate",
@@ -171,7 +171,7 @@
           "caption": "",
           "credit": "YouTube",
           "url": "https://youtu.be/9sj5HcoGK2w",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "Debates at University of South Florida",
@@ -188,7 +188,7 @@
           "caption": "",
           "credit": "<a href=\"http://www.foxnews.com/politics/2012/01/15/huntsman-to-withdraw-from-race-for-republican-presidential-nomination/#ixzz1mzZGCa5Q\" target=\"new\">Huntsman withdraws from race for Republican presidential nomination</a>/FoxNews.com",
           "url": "<blockquote>\"Today, I am suspending my campaign for the presidency. I believe it is now time for our party to unite around the candidate best equipped to defeat Barack Obama. Despite our differences and the space between us on some of the issues, I believe that candidate is Gov. Mitt Romney.\"</blockquote>",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "Huntsman drops out",
@@ -205,7 +205,7 @@
           "caption": "",
           "credit": "<a href=\"http://www.flickr.com/photos/mittromney/6795923698/\" title=\"Untitled by Mitt Romney, on Flickr\">Mitt Romney</a>/Flickr",
           "url": "//farm8.staticflickr.com/7176/6795923698_d11ecca6bc.jpg",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "Michigan and Arizona",
@@ -222,7 +222,7 @@
           "caption": "",
           "credit": "",
           "url": "",
-          "thumb": ""
+          "thumbnail": ""
         },
         "text": {
           "headline": "Super Tuesday",

--- a/website/templates/examples/twain/marktwain.json
+++ b/website/templates/examples/twain/marktwain.json
@@ -71,7 +71,7 @@
                 "headline": "Florida, Missouri",
                 "text": "Born in Florida, Missouri. Halley\u2019s comet visible from earth."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -111,7 +111,7 @@
                 "headline": "Hannibal, Missouri",
                 "text": "Moves to Hannibal, Missouri, which later serves as the model town for Tom Sawyer and Huckleberry Finn."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -140,7 +140,7 @@
                 "headline": "",
                 "text": ""
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -162,7 +162,7 @@
                 "headline": "",
                 "text": ""
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -184,7 +184,7 @@
                 "headline": "",
                 "text": ""
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -213,7 +213,7 @@
                 "headline": "Itinerant Printer",
                 "text": "Visits St. Louis, New York, and Philadelphia as an itinerant printer."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -242,7 +242,7 @@
                 "headline": "Virginia City Territorial Enterprise",
                 "text": "Travels around Nevada and California. Takes job as reporter for the Virginia City Territorial Enterprise."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -276,7 +276,7 @@
                 "headline": "San Francisco",
                 "text": "Forced to leave Nevada for breaking dueling laws. Prospects in Calaveras County, settles in San Francisco. Writes for magazines and newspapers."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -305,7 +305,7 @@
                 "headline": "Hawaii",
                 "text": "Takes trip to Hawaii as correspondent of the Sacramento Alta Californian. Reports on shipwreck of the Hornet. Gives first public lecture."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -334,7 +334,7 @@
                 "headline": "Travels",
                 "text": "Travels as correspondent to Europe and the Holy Land on the Quaker City. Sees a picture of Olivia Langdon (Livy). Publishes The Celebrated Jumping Frog of Calaveras County, and Other Sketches. Sales are light."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -368,7 +368,7 @@
                 "headline": "Livy",
                 "text": "Lectures across the United States. Meets and falls in love with Livy in Elmira, New York."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -401,7 +401,7 @@
                 "headline": "Married",
                 "text": "Marries Livy in Elmira. Her father buys them a house in Buffalo, New York. Son Langdon is born."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -435,7 +435,7 @@
                 "headline": "Roughing It",
                 "text": "Moves with Livy to Hartford. Publishes Roughing It. Daughter is born. Son Langdon dies."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -468,7 +468,7 @@
                 "headline": "Financial",
                 "text": "Leaves Hartford to live in Europe because of financial difficulties."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -490,7 +490,7 @@
                 "headline": "Livy dies",
                 "text": "Livy dies. Begins dictating autobiography. Moves to New York City."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -513,7 +513,7 @@
                 "headline": "Get started!",
                 "text": ""
             },
-            "uniqueid": ""
+            "unique_id": ""
         }
     ]
 }

--- a/website/templates/examples/twain/marktwain.json
+++ b/website/templates/examples/twain/marktwain.json
@@ -6,7 +6,7 @@
             },
             "media": {
                 "url": "https://en.wikipedia.org/wiki/Mark_Twain",
-                "thumb":    "https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Mark_Twain%2C_Brady-Handy_photo_portrait%2C_Feb_7%2C_1871%2C_cropped.jpg/153px-Mark_Twain%2C_Brady-Handy_photo_portrait%2C_Feb_7%2C_1871%2C_cropped.jpg"
+                "thumbnail":    "https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Mark_Twain%2C_Brady-Handy_photo_portrait%2C_Feb_7%2C_1871%2C_cropped.jpg/153px-Mark_Twain%2C_Brady-Handy_photo_portrait%2C_Feb_7%2C_1871%2C_cropped.jpg"
             }
     },
     "events": [
@@ -35,7 +35,7 @@
                 "caption": "Twain caricatured by Spy for Vanity Fair, 1908",
                 "credit": "Vanity Fair",
                 "url": "http://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Mark_Twain_Vanity_Fair_1908-05-13.jpeg/375px-Mark_Twain_Vanity_Fair_1908-05-13.jpeg",
-                "thumb": 	"http://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Mark_Twain_Vanity_Fair_1908-05-13.jpeg/375px-Mark_Twain_Vanity_Fair_1908-05-13.jpeg"
+                "thumbnail": 	"http://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Mark_Twain_Vanity_Fair_1908-05-13.jpeg/375px-Mark_Twain_Vanity_Fair_1908-05-13.jpeg"
             },
             "text": {
                 "headline": "Mark Twain JSON",

--- a/website/templates/test/marktwain.json
+++ b/website/templates/test/marktwain.json
@@ -79,7 +79,7 @@
                 "headline": "Florida, Missouri",
                 "text": "Born in Florida, Missouri. Halley\u2019s comet visible from earth."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -119,7 +119,7 @@
                 "headline": "Hannibal, Missouri",
                 "text": "Moves to Hannibal, Missouri, which later serves as the model town for Tom Sawyer and Huckleberry Finn."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -141,7 +141,7 @@
                 "headline": "",
                 "text": ""
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -173,7 +173,7 @@
                 "headline": "",
                 "text": ""
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -205,7 +205,7 @@
                 "headline": "Vimeo",
                 "text": "vimeo"
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -237,7 +237,7 @@
                 "headline": "",
                 "text": ""
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -269,7 +269,7 @@
                 "headline": "YouTube",
                 "text": "YouTube"
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -301,7 +301,7 @@
                 "headline": "Spotify Track URI",
                 "text": "Visits St. Louis, New York, and Philadelphia as an itinerant printer."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -333,7 +333,7 @@
                 "headline": "Spotify Playlist URI",
                 "text": "Visits St. Louis, New York, and Philadelphia as an itinerant printer."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -365,7 +365,7 @@
                 "headline": "Spotify Playlist URL",
                 "text": "Visits St. Louis, New York, and Philadelphia as an itinerant printer."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -397,7 +397,7 @@
                 "headline": "Twitter",
                 "text": "Moves to Hannibal, Missouri, which later serves as the model town for Tom Sawyer and Huckleberry Finn."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -429,7 +429,7 @@
                 "headline": "Blockquote",
                 "text": "Moves to Hannibal, Missouri, which later serves as the model town for Tom Sawyer and Huckleberry Finn."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -461,7 +461,7 @@
                 "headline": "Spotify Track URL",
                 "text": "Visits St. Louis, New York, and Philadelphia as an itinerant printer."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -488,7 +488,7 @@
                 "headline": "Virginia City Territorial Enterprise",
                 "text": "Travels around Nevada and California. Takes job as reporter for the Virginia City Territorial Enterprise."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -516,7 +516,7 @@
                 "headline": "San Francisco",
                 "text": "Forced to leave Nevada for breaking dueling laws. Prospects in Calaveras County, settles in San Francisco. Writes for magazines and newspapers."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -539,7 +539,7 @@
                 "headline": "Hawaii",
                 "text": "Takes trip to Hawaii as correspondent of the Sacramento Alta Californian. Reports on shipwreck of the Hornet. Gives first public lecture."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -562,7 +562,7 @@
                 "headline": "Travels",
                 "text": "Travels as correspondent to Europe and the Holy Land on the Quaker City. Sees a picture of Olivia Langdon (Livy). Publishes The Celebrated Jumping Frog of Calaveras County, and Other Sketches. Sales are light."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -590,7 +590,7 @@
                 "headline": "Livy",
                 "text": "Lectures across the United States. Meets and falls in love with Livy in Elmira, New York."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -618,7 +618,7 @@
                 "headline": "Married",
                 "text": "Marries Livy in Elmira. Her father buys them a house in Buffalo, New York. Son Langdon is born."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -646,7 +646,7 @@
                 "headline": "Roughing It",
                 "text": "Moves with Livy to Hartford. Publishes Roughing It. Daughter is born. Son Langdon dies."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -674,7 +674,7 @@
                 "headline": "Financial",
                 "text": "Leaves Hartford to live in Europe because of financial difficulties."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -696,7 +696,7 @@
                 "headline": "Livy dies",
                 "text": "Livy dies. Begins dictating autobiography. Moves to New York City."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -725,7 +725,7 @@
                 "headline": "Stormfield",
                 "text": "Moves into Stormfield in Redding, CT. Forms the Angelfish Club for young girls."
             },
-            "uniqueid": ""
+            "unique_id": ""
         }
     ]
 }

--- a/website/templates/test/marktwain.json
+++ b/website/templates/test/marktwain.json
@@ -33,7 +33,7 @@
                 "caption": "Twain caricatured by Spy for Vanity Fair, 1908",
                 "credit": "Vanity Fair",
                 "url": "http://open.spotify.com/track/1OT1G66Lt9EpKFWkwK8i9z",
-                "thumb": 	"http://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Mark_Twain_Vanity_Fair_1908-05-13.jpeg/375px-Mark_Twain_Vanity_Fair_1908-05-13.jpeg"
+                "thumbnail": 	"http://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Mark_Twain_Vanity_Fair_1908-05-13.jpeg/375px-Mark_Twain_Vanity_Fair_1908-05-13.jpeg"
             },
             "text": {
                 "headline": "Mark Twain JSON",

--- a/website/templates/test/marktwain_juked.json
+++ b/website/templates/test/marktwain_juked.json
@@ -33,7 +33,7 @@
                 "caption": "Twain caricatured by Spy for Vanity Fair, 1908",
                 "credit": "Vanity Fair",
                 "url": "http://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Mark_Twain_Vanity_Fair_1908-05-13.jpeg/375px-Mark_Twain_Vanity_Fair_1908-05-13.jpeg",
-                "thumb": 	"http://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Mark_Twain_Vanity_Fair_1908-05-13.jpeg/375px-Mark_Twain_Vanity_Fair_1908-05-13.jpeg"
+                "thumbnail": 	"http://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Mark_Twain_Vanity_Fair_1908-05-13.jpeg/375px-Mark_Twain_Vanity_Fair_1908-05-13.jpeg"
             },
             "text": {
                 "headline": "Mark Twain JSON",

--- a/website/templates/test/marktwain_juked.json
+++ b/website/templates/test/marktwain_juked.json
@@ -69,7 +69,7 @@
                 "headline": "Florida, Missouri",
                 "text": "Born in Florida, Missouri. Halley\u2019s comet visible from earth."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -109,7 +109,7 @@
                 "headline": "Hannibal, Missouri",
                 "text": "Moves to Hannibal, Missouri, which later serves as the model town for Tom Sawyer and Huckleberry Finn."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -138,7 +138,7 @@
                 "headline": "",
                 "text": ""
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -167,7 +167,7 @@
                 "headline": "",
                 "text": ""
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -196,7 +196,7 @@
                 "headline": "",
                 "text": ""
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -225,7 +225,7 @@
                 "headline": "Itinerant Printer",
                 "text": "Visits St. Louis, New York, and Philadelphia as an itinerant printer."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -254,7 +254,7 @@
                 "headline": "Virginia City Territorial Enterprise",
                 "text": "Travels around Nevada and California. Takes job as reporter for the Virginia City Territorial Enterprise."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -288,7 +288,7 @@
                 "headline": "San Francisco",
                 "text": "Forced to leave Nevada for breaking dueling laws. Prospects in Calaveras County, settles in San Francisco. Writes for magazines and newspapers."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -317,7 +317,7 @@
                 "headline": "Hawaii",
                 "text": "Takes trip to Hawaii as correspondent of the Sacramento Alta Californian. Reports on shipwreck of the Hornet. Gives first public lecture."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "start_date": {
@@ -346,7 +346,7 @@
                 "headline": "Travels",
                 "text": "Travels as correspondent to Europe and the Holy Land on the Quaker City. Sees a picture of Olivia Langdon (Livy). Publishes The Celebrated Jumping Frog of Calaveras County, and Other Sketches. Sales are light."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -380,7 +380,7 @@
                 "headline": "Livy",
                 "text": "Lectures across the United States. Meets and falls in love with Livy in Elmira, New York."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -413,7 +413,7 @@
                 "headline": "Married",
                 "text": "Marries Livy in Elmira. Her father buys them a house in Buffalo, New York. Son Langdon is born."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -447,7 +447,7 @@
                 "headline": "Roughing It",
                 "text": "Moves with Livy to Hartford. Publishes Roughing It. Daughter is born. Son Langdon dies."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -480,7 +480,7 @@
                 "headline": "Financial",
                 "text": "Leaves Hartford to live in Europe because of financial difficulties."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -513,7 +513,7 @@
                 "headline": "Livy dies",
                 "text": "Livy dies. Begins dictating autobiography. Moves to New York City."
             },
-            "uniqueid": ""
+            "unique_id": ""
         },
         {
             "background": {
@@ -536,7 +536,7 @@
                 "headline": "Get started!",
                 "text": ""
             },
-            "uniqueid": ""
+            "unique_id": ""
         }
     ]
 }


### PR DESCRIPTION
The new JSON format tends to use full names and separate words with underscores, which is quite nice to see – I particularly like the full date dictionaries – but I noticed a couple of inconsistencies while working on an update for http://www.wdl.org/en/timelines/:

* [ ] [`thumb`](https://github.com/NUKnightLab/TimelineJS3/search?l=javascript&q=thumb&utf8=%E2%9C%93) instead of `thumbnail`
* [x] [`uniqueid`](https://github.com/NUKnightLab/TimelineJS3/blob/829d8999670d76d51f3563666c4ae240eb1ae346/source/js/core/VCO.TimelineConfig.js#L59) instead of `unique_id` or just `id`
* ~~`lat` and `lon` instead of the full `latitude` and `longitude`, although this usage is so common that I think it's less likely to surprise anyone~~