### PR TITLE
Modifications to TL.AxisHelper.js

### DIFF
--- a/config.json
+++ b/config.json
@@ -86,11 +86,11 @@
                 "dst": "build/js/timeline.js"
             },
             {
-                "src": "source/js/Embed/Embed.CDN.js",
+                "src": "source/js/embed/Embed.CDN.js",
                 "dst": "build/js/timeline-embed-cdn.js"
             },
             {
-                "src": "source/js/Embed/Embed.js",
+                "src": "source/js/embed/Embed.js",
                 "dst": "build/js/timeline-embed.js"
             }
         ],

--- a/source/js/timenav/TL.AxisHelper.js
+++ b/source/js/timenav/TL.AxisHelper.js
@@ -81,7 +81,7 @@ TL.AxisHelper = TL.Class.extend({
         }
         
         var prev = null;
-        for (var idx in helpers) {
+        for (var idx = 0; idx < helpers.length; idx++) {
             var curr = helpers[idx];
             var pixels_per_tick = curr.getPixelsPerTick(ts._pixels_per_milli);
             if (pixels_per_tick > optimal_tick_width)  {


### PR DESCRIPTION
**TL.AxisHelper**
If there is any custom **Array.prototype.function** defined, the code will break at line 86
This happens because the **for (var idx in helpers)** will get the custom functions among the helpers

**config.json**
Changed to lower case because linux is case sensitive and breaks the build process
