### PR TITLE
Fix for #331

### DIFF
--- a/compiled/js/timeline.js
+++ b/compiled/js/timeline.js
@@ -10465,7 +10465,7 @@ TL.TimeNav = TL.Class.extend({
 
 	/*	TimeScale
 	================================================== */
-	_getTimeScale: function() {
+	_renewTimeScale: function() {
 		/* maybe the establishing config values (marker_height_min and max_rows) should be
 		separated from making a TimeScale object, which happens in another spot in this file with duplicate mapping of properties of this TimeNav into the TimeScale options object? */
 		// Set Max Rows
@@ -10922,7 +10922,7 @@ TL.TimeNav = TL.Class.extend({
 		}
 		if (height && height != this.options.height) {
 			this.options.height = height;
-			this.timescale = this._getTimeScale();
+			this._renewTimeScale();
 		}
 
 		// Size Markers
@@ -10941,7 +10941,7 @@ TL.TimeNav = TL.Class.extend({
 	},
 
 	_drawTimeline: function(fast) {
-		this.timescale = this._getTimeScale();
+		this._renewTimeScale();
 		this.timeaxis.drawTicks(this.timescale, this.options.optimal_tick_width);
 		this._positionMarkers(fast);
 		this._assignRowsToMarkers();
@@ -10958,7 +10958,7 @@ TL.TimeNav = TL.Class.extend({
 
 		// Check to see if redraw is needed
 		if (check_update) {
-			/* keep this aligned with _getTimeScale or reduce code duplication */
+			/* keep this aligned with _renewTimeScale or reduce code duplication */
 			var temp_timescale = new TL.TimeScale(this.config, {
 	            display_width: this._el.container.offsetWidth,
 	            screen_multiplier: this.options.scale_factor,
@@ -10976,7 +10976,7 @@ TL.TimeNav = TL.Class.extend({
 
 		// Perform update or redraw
 		if (do_update) {
-			this.timescale = this._getTimeScale();
+			this._renewTimeScale();
 			this.timeaxis.positionTicks(this.timescale, this.options.optimal_tick_width);
 			this._positionMarkers();
 			this._assignRowsToMarkers();

--- a/compiled/js/timeline.js
+++ b/compiled/js/timeline.js
@@ -10484,12 +10484,13 @@ TL.TimeNav = TL.Class.extend({
 		if (this.max_rows < 1) {
 			this.max_rows = 1;
 		}
-		return new TL.TimeScale(this.config, {
+		this.timescale = new TL.TimeScale(this.config, {
             display_width: this._el.container.offsetWidth,
             screen_multiplier: this.options.scale_factor,
-            max_rows: this.max_rows
-
-		});
+            max_rows: this.max_rows});
+		this._groups = [];
+		this._createGroups();
+		return this.timescale;
 	},
 
 	_updateTimeScale: function(new_scale) {
@@ -10944,7 +10945,6 @@ TL.TimeNav = TL.Class.extend({
 		this.timeaxis.drawTicks(this.timescale, this.options.optimal_tick_width);
 		this._positionMarkers(fast);
 		this._assignRowsToMarkers();
-		this._createGroups();
 		this._positionGroups();
 
 		if (this.has_eras) {

--- a/source/js/timenav/TL.TimeNav.js
+++ b/source/js/timenav/TL.TimeNav.js
@@ -141,12 +141,13 @@ TL.TimeNav = TL.Class.extend({
 		if (this.max_rows < 1) {
 			this.max_rows = 1;
 		}
-		return new TL.TimeScale(this.config, {
+		this.timescale = new TL.TimeScale(this.config, {
             display_width: this._el.container.offsetWidth,
             screen_multiplier: this.options.scale_factor,
-            max_rows: this.max_rows
-
-		});
+            max_rows: this.max_rows});
+		this._groups = [];
+		this._createGroups();
+		return this.timescale;
 	},
 
 	_updateTimeScale: function(new_scale) {
@@ -601,7 +602,6 @@ TL.TimeNav = TL.Class.extend({
 		this.timeaxis.drawTicks(this.timescale, this.options.optimal_tick_width);
 		this._positionMarkers(fast);
 		this._assignRowsToMarkers();
-		this._createGroups();
 		this._positionGroups();
 
 		if (this.has_eras) {

--- a/source/js/timenav/TL.TimeNav.js
+++ b/source/js/timenav/TL.TimeNav.js
@@ -122,7 +122,7 @@ TL.TimeNav = TL.Class.extend({
 
 	/*	TimeScale
 	================================================== */
-	_getTimeScale: function() {
+	_renewTimeScale: function() {
 		/* maybe the establishing config values (marker_height_min and max_rows) should be
 		separated from making a TimeScale object, which happens in another spot in this file with duplicate mapping of properties of this TimeNav into the TimeScale options object? */
 		// Set Max Rows
@@ -579,7 +579,7 @@ TL.TimeNav = TL.Class.extend({
 		}
 		if (height && height != this.options.height) {
 			this.options.height = height;
-			this.timescale = this._getTimeScale();
+			this._renewTimeScale();
 		}
 
 		// Size Markers
@@ -598,7 +598,7 @@ TL.TimeNav = TL.Class.extend({
 	},
 
 	_drawTimeline: function(fast) {
-		this.timescale = this._getTimeScale();
+		this._renewTimeScale();
 		this.timeaxis.drawTicks(this.timescale, this.options.optimal_tick_width);
 		this._positionMarkers(fast);
 		this._assignRowsToMarkers();
@@ -615,7 +615,7 @@ TL.TimeNav = TL.Class.extend({
 
 		// Check to see if redraw is needed
 		if (check_update) {
-			/* keep this aligned with _getTimeScale or reduce code duplication */
+			/* keep this aligned with _renewTimeScale or reduce code duplication */
 			var temp_timescale = new TL.TimeScale(this.config, {
 	            display_width: this._el.container.offsetWidth,
 	            screen_multiplier: this.options.scale_factor,
@@ -633,7 +633,7 @@ TL.TimeNav = TL.Class.extend({
 
 		// Perform update or redraw
 		if (do_update) {
-			this.timescale = this._getTimeScale();
+			this._renewTimeScale();
 			this.timeaxis.positionTicks(this.timescale, this.options.optimal_tick_width);
 			this._positionMarkers();
 			this._assignRowsToMarkers();


### PR DESCRIPTION
Investigation of #331
1) `TimeNav::timescale` is re-newed when zoom event fired.
2) That constructor calls `TimeScale::_computePositionInfo()` to recalc number of rows per group.
3) But `TimeNav::_groups[]` has not been updated. 
