### PR TITLE
Fix background image scrolling on long slide.

### DIFF
--- a/source/less/slider/TL.Slide.less
+++ b/source/less/slider/TL.Slide.less
@@ -31,9 +31,11 @@
 		overflow-y:auto;
 	}
 	.tl-slide-content-container {
-		display:flex;
-		flex-direction:column;
-		justify-content:center;
+		display: -webkit-flex;
+		display: flex;
+		align-items: center;
+		-webkit-align-items: center;
+
 		position:relative;
 		width:100%;
 		min-height:100%;
@@ -237,10 +239,6 @@
 	.tl-slide {
 		display:block;
 		.tl-slide-content-container {
-			display:block;
-			position:static;
-			height:auto;
-			height:100%;
 			//vertical-align:baseline;
 			.tl-slide-content {
 				display:block;

--- a/source/less/slider/TL.Slide.less
+++ b/source/less/slider/TL.Slide.less
@@ -31,10 +31,13 @@
 		overflow-y:auto;
 	}
 	.tl-slide-content-container {
+		display:flex;
+		flex-direction:column;
+		justify-content:center;
 		position:relative;
 		width:100%;
-		height:100%;
-		
+		min-height:100%;
+
 		z-index:3;
 		.tl-slide-content {
 			//width:100%;

--- a/source/less/slider/TL.Slide.less
+++ b/source/less/slider/TL.Slide.less
@@ -6,9 +6,7 @@
 	height:100%;
 	padding:0px;
 	margin:0px;
-	overflow-x:hidden;
-	overflow-y:auto;
-	
+
 	.tl-slide-background {
 		position:absolute;
 		left:0;
@@ -26,14 +24,13 @@
 			    background-size: cover;
 	}
 	.tl-slide-scrollable-container {
-		display:table;
-		table-layout: fixed;
 		height:100%;
+		padding-top:10px;
 		z-index:1;
+		overflow-x:hidden;
+		overflow-y:auto;
 	}
 	.tl-slide-content-container {
-		display:table-cell;
-		vertical-align:middle;
 		position:relative;
 		width:100%;
 		height:100%;
@@ -236,18 +233,12 @@
 
 	.tl-slide {
 		display:block;
-		padding-top:10px;
 		.tl-slide-content-container {
 			display:block;
 			position:static;
 			height:auto;
 			height:100%;
 			//vertical-align:baseline;
-			display: -webkit-flex; /* Safari */
-			display: flex;
-			//flex-direction:column-reverse;
-			align-items: center;
-			-webkit-align-items: center; /* Safari 7.0+ */
 			.tl-slide-content {
 				display:block;
 


### PR DESCRIPTION
Fixes #360 
This changes which element on the slide scrolls so that the background image stays fixed.

Here is the example we used to recreate and fix the issue:
https://docs.google.com/spreadsheets/d/1U3uJXZO9CMnYzOaKVRCqbFD_5vxnAb7JmHoSiIhMenI/pubhtml 
