### PR TITLE
Removed Year 0 from TimeAxis Display (Fixes Issue#328)

### DIFF
--- a/source/js/timenav/TL.TimeAxis.js
+++ b/source/js/timenav/TL.TimeAxis.js
@@ -164,7 +164,11 @@ TL.TimeAxis = TL.Class.extend({
 
 	_createTickElements: function(ts_ticks,tick_element,dateformat,ticks_to_skip) {
 		tick_element.innerHTML = "";
-		var skip_times = {}
+		var skip_times = {};
+
+		var yearZero = new Date(-1,13,-30);
+		skip_times[yearZero.getTime()] = true;
+
 		if (ticks_to_skip){
 			for (var i = 0; i < ticks_to_skip.length; i++) {
 				skip_times[ticks_to_skip[i].getTime()] = true;


### PR DESCRIPTION
The Timeline axis should have '0' removed from the display now (referenced here: https://github.com/NUKnightLab/TimelineJS3/issues/328) - however, there's now a gap with nothing displaying there. Is that fine, or should it be replaced with Year 1 instead?

<img width="345" alt="screen shot 2016-10-10 at 12 58 46 pm" src="https://cloud.githubusercontent.com/assets/12781097/19245951/81eb5564-8ee9-11e6-8839-7fedbbe664c5.png">

@scott2b @rosaliechan 
