### PR TITLE
add gulp build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ codekit-config.json
 build/website
 build
 *.log
+
+/node_modules

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,110 @@
+var gulp 	= require('gulp'),
+	include = require('gulp-include'),
+	less 	= require('gulp-less'),
+	clean 	= require('less-plugin-clean-css'),
+	rename 	= require('gulp-rename'),
+	uglify	= require('gulp-uglify'),
+	usemin 	= require('gulp-usemin'),
+	banner	= require('gulp-banner'),
+	package = require('./package.json');
+
+gulp.task('js', function() {
+	gulp.src('source/js/TL.Timeline.js')
+		.pipe(include())
+		.pipe(rename('timeline.js'))
+		.pipe(gulp.dest('build/js/'))
+		.pipe(uglify())
+		.pipe(rename('timeline-min.js'))
+		.pipe(gulp.dest('build/js'));
+
+	gulp.src('source/js/embed/Embed.CDN.js')
+		.pipe(include())
+		.pipe(rename('timeline-embed-cdn.js'))
+		.pipe(gulp.dest('build/js'));
+
+	gulp.src('source/js/embed/Embed.js')
+		.pipe(include())
+		.pipe(rename('timeline-embed.js'))
+		.pipe(gulp.dest('build/js'));
+
+	gulp.src('source/js/library/moment.js')
+		.pipe(uglify())
+		.pipe(gulp.dest('build/js/library'))
+});
+
+gulp.task('less', function() {
+	var cleanCss = new clean({ 'clean-css': '--s0' });
+
+	gulp.src('source/less/TL.Timeline.less')
+		.pipe(less({
+			plugins: [cleanCss]
+		}))
+		.pipe(rename('timeline.css'))
+		.pipe(gulp.dest('build/css'));
+
+	gulp.src('source/less/themes/dark/TL.Theme.Dark.less')
+		.pipe(less({
+			plugins: [cleanCss]
+		}))
+		.pipe(rename('timeline.theme.dark.css'))
+		.pipe(gulp.dest('build/css/themes'));
+
+	gulp.src('source/less/fonts/[^font.base].less')
+		.pipe(less())
+		.pipe(gulp.dest('build/css/fonts/'));
+});
+
+gulp.task('copy', function() {
+	gulp.src([
+			'website/css/*.*',
+			'website/img/*.*',
+			'website/js/*.*',
+			'website/ico/*.*'
+		])
+		.pipe(gulp.dest('build'));
+
+	gulp.src([
+			'source/css/*.*',
+			'source/img/*.*',
+			'source/gfx/*.png',
+			'source/gfx/*.jpg',
+			'source/gfx/*.gif',
+			'source/ico/*.*',
+			'source/**/*.ico',
+			'source/**/*.html',
+		])
+		.pipe(gulp.dest('build'));
+
+	gulp.src('source/js/language/locale/*.json')
+		.pipe(gulp.dest('build/js/locale'));
+
+	gulp.src('source/embed')
+		.pipe(gulp.dest('build'));
+});
+
+gulp.task('usemin', function() {
+	gulp.src('build/embed')
+		.pipe(usemin())
+		.pipe(gulp.dest('build'));
+});
+
+gulp.task('banner', function() {
+	var comment = 	"/*\n" +
+	                "    TimelineJS - ver. <%= package.version %> - <%= date %>\n" +
+	                "    Copyright (c) 2012-2016 Northwestern University\n" +
+	                "    a project of the Northwestern University Knight Lab + originally created by Zach Wise\n" +
+	                "    https://github.com/NUKnightLab/TimelineJS3\n" +
+	                "    This Source Code Form is subject to the terms of the Mozilla Public License + v. 2.0.\n" +
+	                "    If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.\n" +
+	                "*/\n\n"
+
+	gulp.src('build/js/*.js')
+		.pipe(banner(comment, {package: package, date: Date.now().toLocaleString()}))
+		.pipe(gulp.dest('build/js'));
+
+	gulp.src('build/css/*.css')
+		.pipe(banner(comment, {package: package, date: Date.now().toLocaleString()}))
+		.pipe(gulp.dest('build/css'));
+});
+
+gulp.task('default', ['js', 'less', 'copy', 'usemin', 'banner']);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "timelinejs3",
+  "version": "1.0.0",
+  "description": "============",
+  "main": "gulpfile.js",
+  "dependencies": {
+    "dotenv": "^2.0.0",
+    "gulp": "^3.9.1",
+    "gulp-banner": "^0.1.3",
+    "gulp-codekit": "^0.1.3",
+    "gulp-less": "^3.1.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-include": "^2.3.1",
+    "gulp-uglify": "^2.0.0",
+    "gulp-usemin": "^0.3.24",
+    "less": "^2.1.1",
+    "less-plugin-clean-css": "^1.2.0",
+    "parallelshell": "^2.0.0",
+    "uglify-js": "^2.7.3",
+    "webpack": "^1.13.2"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NUKnightLab/TimelineJS3.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/thehandsomepanther/TimelineJS3/issues"
+  },
+  "homepage": "https://github.com/thehandsomepanther/TimelineJS3#readme"
+}

--- a/source/js/TL.Timeline.js
+++ b/source/js/TL.Timeline.js
@@ -18,87 +18,150 @@ https://incident57.com/codekit/
 
 // CORE
 	// @codekit-prepend "core/TL.js";
+	//=include core/TL.js
 	// @codekit-prepend "core/TL.Error.js";
+	//=include core/TL.Error.js
 	// @codekit-prepend "core/TL.Util.js";
+	//=include core/TL.Util.js
 	// @codekit-prepend "data/TL.Data.js";
+	//=include data/TL.Data.js
 	// @codekit-prepend "core/TL.Class.js";
+	//=include core/TL.Class.js
 	// @codekit-prepend "core/TL.Events.js";
+	//=include core/TL.Events.js
 	// @codekit-prepend "core/TL.Browser.js";
+	//=include core/TL.Browser.js
 	// @codekit-prepend "core/TL.Load.js";
+	//=include core/TL.Load.js
 	// @codekit-prepend "core/TL.TimelineConfig.js";
+	//=include core/TL.TimelineConfig.js
 	// @codekit-prepend "core/TL.ConfigFactory.js";
+	//=include core/TL.ConfigFactory.js
 
 
 // LANGUAGE
 	// @codekit-prepend "language/TL.Language.js";
+	//=include language/TL.Language.js
 	// @codekit-prepend "language/TL.I18NMixins.js";
+	//=include language/TL.I18NMixins.js
 
 // ANIMATION
 	// @codekit-prepend "animation/TL.Ease.js";
+	//=include animation/TL.Ease.js
 	// @codekit-prepend "animation/TL.Animate.js";
+	//=include animation/TL.Animate.js
 
 // DOM
 	// @codekit-prepend "dom/TL.Point.js";
+	//=include dom/TL.Point.js
 	// @codekit-prepend "dom/TL.DomMixins.js";
+	//=include dom/TL.DomMixins.js
 	// @codekit-prepend "dom/TL.Dom.js";
+	//=include dom/TL.Dom.js
 	// @codekit-prepend "dom/TL.DomUtil.js";
+	//=include dom/TL.DomUtil.js
 	// @codekit-prepend "dom/TL.DomEvent.js";
+	//=include dom/TL.DomEvent.js
 	// @codekit-prepend "dom/TL.StyleSheet.js";
+	//=include dom/TL.StyleSheet.js
 
 // Date
 	// @codekit-prepend "date/TL.Date.js";
+	//=include date/TL.Date.js
 	// @codekit-prepend "date/TL.DateUtil.js";
+	//=include date/TL.DateUtil.js
 
 // UI
 	// @codekit-prepend "ui/TL.Draggable.js";
+	//=include ui/TL.Draggable.js
 	// @codekit-prepend "ui/TL.Swipable.js";
+	//=include ui/TL.Swipable.js
 	// @codekit-prepend "ui/TL.MenuBar.js";
+	//=include ui/TL.MenuBar.js
 	// @codekit-prepend "ui/TL.Message.js";
+	//=include ui/TL.Message.js
 
 // MEDIA
 	// @codekit-prepend "media/TL.MediaType.js";
+	//=include media/TL.MediaType.js
 	// @codekit-prepend "media/TL.Media.js";
+	//=include media/TL.Media.js
 
 // MEDIA TYPES
 	// @codekit-prepend "media/types/TL.Media.Blockquote.js";
+	//=include media/types/TL.Media.Blockquote.js
 	// @codekit-prepend "media/types/TL.Media.DailyMotion.js";
+	//=include media/types/TL.Media.DailyMotion.js
 	// @codekit-prepend "media/types/TL.Media.DocumentCloud.js";
+	//=include media/types/TL.Media.DocumentCloud.js
 	// @codekit-prepend "media/types/TL.Media.Flickr.js";
+	//=include media/types/TL.Media.Flickr.js
 	// @codekit-prepend "media/types/TL.Media.GoogleDoc.js";
+	//=include media/types/TL.Media.GoogleDoc.js
 	// @codekit-prepend "media/types/TL.Media.GooglePlus.js";
+	//=include media/types/TL.Media.GooglePlus.js
 	// @codekit-prepend "media/types/TL.Media.IFrame.js";
+	//=include media/types/TL.Media.IFrame.js
 	// @codekit-prepend "media/types/TL.Media.Image.js";
+	//=include media/types/TL.Media.Image.js
 	// @codekit-prepend "media/types/TL.Media.Imgur.js";
+	//=include media/types/TL.Media.Imgur.js
 	// @codekit-prepend "media/types/TL.Media.Instagram.js";
+	//=include media/types/TL.Media.Instagram.js
 	// @codekit-prepend "media/types/TL.Media.GoogleMap.js";
+	//=include media/types/TL.Media.GoogleMap.js
 	// @codekit-prepend "media/types/TL.Media.PDF.js";
+	//=include media/types/TL.Media.PDF.js
 	// @codekit-prepend "media/types/TL.Media.Profile.js";
+	//=include media/types/TL.Media.Profile.js
 	// @codekit-prepend "media/types/TL.Media.Slider.js";
+	//=include media/types/TL.Media.Slider.js
 	// @codekit-prepend "media/types/TL.Media.SoundCloud.js";
+	//=include media/types/TL.Media.SoundCloud.js
 	// @codekit-prepend "media/types/TL.Media.Spotify.js";
+	//=include media/types/TL.Media.Spotify.js
 	// @codekit-prepend "media/types/TL.Media.Storify.js";
+	//=include media/types/TL.Media.Storify.js
 	// @codekit-prepend "media/types/TL.Media.Text.js";
+	//=include media/types/TL.Media.Text.js
 	// @codekit-prepend "media/types/TL.Media.Twitter.js";
+	//=include media/types/TL.Media.Twitter.js
 	// @codekit-prepend "media/types/TL.Media.TwitterEmbed.js";
+	//=include media/types/TL.Media.TwitterEmbed.js
 	// @codekit-prepend "media/types/TL.Media.Vimeo.js";
+	//=include media/types/TL.Media.Vimeo.js
 	// @codekit-prepend "media/types/TL.Media.Vine.js";
+	//=include media/types/TL.Media.Vine.js
 	// @codekit-prepend "media/types/TL.Media.Website.js";
+	//=include media/types/TL.Media.Website.js
 	// @codekit-prepend "media/types/TL.Media.Wikipedia.js";
+	//=include media/types/TL.Media.Wikipedia.js
 	// @codekit-prepend "media/types/TL.Media.YouTube.js";
+	//=include media/types/TL.Media.YouTube.js
 
 // STORYSLIDER
 	// @codekit-prepend "slider/TL.Slide.js";
+	//=include slider/TL.Slide.js
 	// @codekit-prepend "slider/TL.SlideNav.js";
+	//=include slider/TL.SlideNav.js
 	// @codekit-prepend "slider/TL.StorySlider.js";
+	//=include slider/TL.StorySlider.js
 
 // TIMENAV
 	// @codekit-prepend "timenav/TL.TimeNav.js";
+	//=include timenav/TL.TimeNav.js
 	// @codekit-prepend "timenav/TL.TimeMarker.js";
+	//=include timenav/TL.TimeMarker.js
 	// @codekit-prepend "timenav/TL.TimeEra.js";
+	//=include timenav/TL.TimeEra.js
 	// @codekit-prepend "timenav/TL.TimeGroup.js";
+	//=include timenav/TL.TimeGroup.js
 	// @codekit-prepend "timenav/TL.TimeScale.js";
+	//=include timenav/TL.TimeScale.js
 	// @codekit-prepend "timenav/TL.TimeAxis.js";
+	//=include timenav/TL.TimeAxis.js
 	// @codekit-prepend "timenav/TL.AxisHelper.js";
+	//=include timenav/TL.AxisHelper.js
 
 
 TL.Timeline = TL.Class.extend({

--- a/source/js/embed/Embed.CDN.js
+++ b/source/js/embed/Embed.CDN.js
@@ -6,6 +6,7 @@
   https://incident57.com/codekit/
 ================================================== */
 // @codekit-append "Embed.js";
+//=include Embed.js
 
 /* REPLACE THIS WITH YOUR GOOGLE ANALYTICS ACCOUNT
 ================================================== */

--- a/source/js/embed/Embed.js
+++ b/source/js/embed/Embed.js
@@ -5,6 +5,7 @@
   https://incident57.com/codekit/
 ================================================== */
 // @codekit-prepend "Embed.LoadLib.js";
+//=include Embed.LoadLib.js
 
 if(typeof embed_path == 'undefined') {
   // REPLACE WITH YOUR BASEPATH IF YOU WANT OTHERWISE IT WILL TRY AND FIGURE IT OUT


### PR DESCRIPTION
This uses gulp because I wasn't able to find a good module outside of gulp for inserting Codekit prepends into the built Javascript. There also doesn't seem to be a gulp plugin for the actual Codekit prepend syntax `// @codekit-append "<filename>";`, so I used the gulp-include plugin, which uses a slightly different syntax, `//=include Embed.js`, to accomplish the same thing.
