### PR TITLE
Revert "reinstates display table layout required for non-flex support in IE; …"

### DIFF
--- a/source/less/slider/TL.Slide.less
+++ b/source/less/slider/TL.Slide.less
@@ -17,24 +17,19 @@
 		overflow:hidden;
 		display:none;
 		.opacity(50);
-		background: no-repeat center center;
+		background: no-repeat center center; 
 		-webkit-background-size: cover;
 		   -moz-background-size: cover;
 		     -o-background-size: cover;
 			    background-size: cover;
 	}
 	.tl-slide-scrollable-container {
-		display: table;
-		display: -webkit-flex;
-		display: flex;
 		height:100%;
 		z-index:1;
 		overflow-x:hidden;
 		overflow-y:auto;
 	}
 	.tl-slide-content-container {
-		display: table-cell;
-		vertical-align: middle;
 		display: -webkit-flex;
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
Reverts NUKnightLab/TimelineJS3#428. prerequisite to reverting #387 which causes slides to be cut off at the top on small screens