### PR TITLE
adjust html lang attribute based on spreadsheet parameters #425

### DIFF
--- a/source/embed/index.html
+++ b/source/embed/index.html
@@ -32,6 +32,11 @@ html, body {
   <div id="timeline-embed"></div>
   <!-- Override -->
   <script type="text/javascript">
+    var lang = window.location.href.match(/&lang=([a-zA-Z]*)&?/);
+
+    if (lang) {
+      document.getElementsByTagName('html')[0].setAttribute('lang', lang[1]);
+    }
     var trim_point = window.location.href.indexOf('embed/index.html');
     if (trim_point > 0) {
       var embed_path = window.location.href.substring(0,trim_point); // supports https access via https://s3.amazonaws.com/cdn.knightlab.com/libs/timeline/latest/embed/index.html


### PR DESCRIPTION
this issue https://github.com/NUKnightLab/TimelineJS3/issues/425 brings up that screen readers don't work on foreign language timelines because the `html` tag in the iframe is set by default to `en`. This PR grabs the `lang` attribute from the source url and sets the lang attribute to that.