### PR TITLE
Added metadata for FB+Twitter

### DIFF
--- a/website/templates/_head.html
+++ b/website/templates/_head.html
@@ -18,7 +18,7 @@
 
     <!-- Open Graph -->
    <meta property="og:type" content="article" />
-   <meta property="og:title" content="{{title}}" />
+   <meta property="og:title" content="TimelineJS3" />
    <meta property="og:description" content="Easy-to-make, beautiful timelines." />
    <meta property="og:image" content="https://cdn.knightlab.com/libs/purpleline/latest/img/logos/logo_horizontal_691x206_transparent_NOpadding.png" />
    <meta property="og:url" content="https://timeline.knightlab.com/" />
@@ -26,7 +26,7 @@
    <!-- /Open Graph -->
 
    <!-- Twitter Card -->
-   <meta name="twitter:title" content="{{title}}">
+   <meta name="twitter:title" content="TimelineJS3">
    <meta name="twitter:description" content="Easy-to-make, beautiful timelines.">
    <meta name="twitter:image" content="https://cdn.knightlab.com/libs/purpleline/latest/img/logos/logo_horizontal_691x206_transparent_NOpadding.png">
    <meta name="twitter:site" content="@knightlab">

--- a/website/templates/_head.html
+++ b/website/templates/_head.html
@@ -15,3 +15,20 @@
     <link rel="mask-icon" href="https://cdn.knightlab.com/libs/orangeline/latest/assets/favicons/safari-pinned-tab.svg" color="#5bbad5">
     <meta name="theme-color" content="#ffffff">
     <!-- /favicons -->
+
+    <!-- Open Graph -->
+   <meta property="og:type" content="article" />
+   <meta property="og:title" content="{{title}}" />
+   <meta property="og:description" content="Easy-to-make, beautiful timelines." />
+   <meta property="og:image" content="https://cdn.knightlab.com/libs/purpleline/latest/img/logos/logo_horizontal_691x206_transparent_NOpadding.png" />
+   <meta property="og:url" content="https://timeline.knightlab.com/" />
+   <meta property="og:site_name" content="Timeline JS3" />
+   <!-- /Open Graph -->
+
+   <!-- Twitter Card -->
+   <meta name="twitter:title" content="{{title}}">
+   <meta name="twitter:description" content="Easy-to-make, beautiful timelines.">
+   <meta name="twitter:image" content="https://cdn.knightlab.com/libs/purpleline/latest/img/logos/logo_horizontal_691x206_transparent_NOpadding.png">
+   <meta name="twitter:site" content="@knightlab">
+   <meta name="twitter:creator" content="@knightlab">
+   <!-- /Twitter Card -->


### PR DESCRIPTION
Used template referenced [here](https://github.com/NUKnightLab/orangeline/issues/58). 

**Questions**
1. Do we want to use the image referenced [here](https://cdn.knightlab.com/libs/purpleline/latest/img/logos/logo_horizontal_691x206_transparent_NOpadding.png) as the image for all the projects?
2. Would the Twitter creator be "knightlab" or "zlwise"