### PR TITLE
Local previews 

### DIFF
--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -89,7 +89,10 @@ function getLinkAndIframe() {
   if ((window.location.host).includes("localhost:") || (window.location.host).includes("0.0.0.0:") ){
     urlBase = "http://" + window.location.host + "/source/";
   }
-  else{
+  else if ((window.location.host).includes("timeline.knilab.com")){
+    urlBase = "http://cdn.knightlab.com/libs/timeline3/dev/";
+  }
+  else {
     urlBase = "https://cdn.knightlab.com/libs/timeline3/latest/";
   }
 

--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -85,11 +85,22 @@ function getLinkAndIframe() {
 
   /* IFRAME AND LINK
   ================================================== */
-  vars    =  "https://cdn.knightlab.com/libs/timeline3/latest/embed/index.html?source=" + source_key;
 
   if ((window.location.host).includes("localhost:") || (window.location.host).includes("0.0.0.0:") ){
-    vars    =  "http://" + window.location.host + "/source/embed/index.html?source=" + source_key;
+    urlBase = "http://" + window.location.host + "/source/";
   }
+  else{
+    urlBase = "https://cdn.knightlab.com/libs/timeline3/latest/";
+  }
+
+  vars    =  urlBase + "embed/index.html?source=" + source_key;
+
+  vars    += "&font=" + e_font.getAttribute("data-value");
+  vars    += "&lang=" + e_language.value;
+
+  if (start_at_end) {
+    vars  += "&start_at_end=" + start_at_end;
+  } 
 
   if (timenav_position == "top") {
     vars += "&timenav_position=" + timenav_position;

--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -85,13 +85,12 @@ function getLinkAndIframe() {
 
   /* IFRAME AND LINK
   ================================================== */
-//  vars    =  generator_embed_path + "?source=" + source_key;
   vars    =  "https://cdn.knightlab.com/libs/timeline3/latest/embed/index.html?source=" + source_key;
-  vars    += "&font=" + e_font.getAttribute("data-value");
-  vars    += "&lang=" + e_language.value;
-  if (start_at_end) {
-    vars  += "&start_at_end=" + start_at_end;
+
+  if ((window.location.host).includes("localhost:") || (window.location.host).includes("0.0.0.0:") ){
+    vars    =  "http://" + window.location.host + "/source/embed/index.html?source=" + source_key;
   }
+
   if (timenav_position == "top") {
     vars += "&timenav_position=" + timenav_position;
   }


### PR DESCRIPTION
On local builds, the Timeline website should now generate previews based on locally built JS files instead of CDN hosted JS files.