### PR TITLE
made minor ticks same color as major ticks

### DIFF
--- a/source/less/timenav/TL.TimeAxis.less
+++ b/source/less/timenav/TL.TimeAxis.less
@@ -99,7 +99,8 @@
 			.tl-timeaxis-tick {
 				font-size:@minor-ticks-font-size;
 				line-height:@minor-ticks-font-size + @tick-padding;
-				color:@minor-ticks-color;
+//				color:@minor-ticks-color;
+                color:@major-ticks-color;
 				width:@minor-ticks-width;
 				margin-left:-(@minor-ticks-width/2);
 				.tl-timeaxis-tick-text {
@@ -113,7 +114,8 @@
 						font-size:9px;
 						line-height:9px;
 						margin-top:-2px;
-						color:lighten(@minor-ticks-color,15);
+//						color:lighten(@minor-ticks-color,15);
+                        color:@major-ticks-color;
 						&.tl-timeaxis-timesuffix {
 							//display:none;
 						}


### PR DESCRIPTION
Potential fix for this: https://github.com/NUKnightLab/TimelineJS3/issues/509
Would we want the minor tick dates to be the same color as the major tick dates so it's easier to read?
<img width="287" alt="screen shot 2017-05-23 at 5 15 16 pm" src="https://cloud.githubusercontent.com/assets/8533482/26378806/c46139e2-3fdb-11e7-9215-c38fb91d7598.png">
@zachwise @scott2b 