### PR TITLE
adds rtl direction to .tl-rtl

### DIFF
--- a/source/less/TL.Timeline.Base.less
+++ b/source/less/TL.Timeline.Base.less
@@ -95,6 +95,7 @@
 .tl-rtl{
 	.tl-text-content, .tl-headline, .tl-media-blockquote, .tl-headline-date, .tl-timeline blockquote p, .tl-media-website, .tl-media-wikipedia, .tl-media .tl-media-blockquote blockquote, .blockquote, blockquote p, .tl-text-content p{
 		text-align: right;
+		direction: rtl;
 	}
 
 	.tl-slide-media-only{


### PR DESCRIPTION
Per zendesk # 5121

Fixes lack of direction on .tl-rtl class for right-to-left languages

ping: @JoeGermuska @zachwise 