### PR TITLE
Groups layout fix 331

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,13 @@
+# Community Contributions
+
+## Disclaimer
+
+Files in this directory have been contributed by the community. No review, testing, or verification for anything here has been done by the Knight Lab. Please use with caution and at your own risk.
+
+## Organization
+
+Contributions are organized into directories according to the submitter's GitHub username.
+
+## Contributing
+
+If you have made something for TimelineJS that you thing would be useful to the community, please submit it via pull request in the GitHub repository: https://github.com/NUKnightLab/TimelineJS3

--- a/contrib/fedorbeets/README.md
+++ b/contrib/fedorbeets/README.md
@@ -1,0 +1,3 @@
+A version of timeline.py from @iamamoose that will also convert era's
+
+See: https://github.com/NUKnightLab/TimelineJS3/issues/398

--- a/contrib/fedorbeets/timeline.py.txt
+++ b/contrib/fedorbeets/timeline.py.txt
@@ -1,0 +1,56 @@
+# Convert google doc spreadsheet format for timelinejs to json file
+# useful if you want to experiment using google doc but eventually
+# host everything yourself privately.
+
+# Example: go to google docs spreadsheet and do File -> Download As -> CSV (Comma Separated Values)
+# save as timeline.csv, run this, you get a timeline.json out
+#
+# Or look at your google doc ID long string like for example 1xTn9OSdmnxbBtQcKxZYV-xXkKoOpPSu6AUT0LXXszHo
+# wget -qO timeline.csv 'https://docs.google.com/spreadsheets/d/1xTn9OSdmnxbBtQcKxZYV-xXkKoOpPSu6AUT0LXXszHo/pub?output=csv'
+
+import csv
+import json
+
+csvfile = open('timeline.csv','rb')
+outfile = open('timeline.json','w')
+reader = csv.DictReader(csvfile)
+
+data = {}
+events = []
+eras = []
+data['events']=events
+data['eras']=eras
+
+# Didn't support 'End Time': '', 'Time': ''
+
+keymap = {'Media': 'media|url', 'Media Caption': 'media|caption', 'Media Thumbnail': 'media|thumbnail',
+          'Month': 'start_date|month', 'Day': 'start_date|day', 'Year': 'start_date|year',
+          'End Month': 'end_date|month', 'End Day': 'end_date|day', 'End Year': 'end_date|year',
+          'Headline': 'text|headline', 'Text': 'text|text',
+          'Group': 'group', 'Display Date': 'display_date'}
+
+for row in reader:
+    event = {}
+    for a in keymap:
+        if row[a]:
+            if '|' in keymap[a]:
+                (x,y)=keymap[a].split("|")
+                if not x in event: event[x]={}
+                event[x][y] = row[a]
+            else:
+                event[keymap[a]] = row[a]
+
+    if row['Background']:
+        event['background'] = {}
+        if row['Background'].startswith("#"):
+            event['background']['color']=row['Background']
+        else:
+            event['background']['url']=row['Background']
+    if (row['Type'] == 'title'):
+        data['title']=event
+    elif (row['Type'] == 'era'):
+        eras.append(event)
+    else:
+        events.append(event)
+
+json.dump(data,outfile, sort_keys=True,indent=4)

--- a/contrib/iamamoose/README.md
+++ b/contrib/iamamoose/README.md
@@ -1,0 +1,3 @@
+We tested out using TimelineJS using a google spreadsheet but wanted to then move everything internal. Rather than rewrite everything I made this Python program that can take the spreadsheet and convert it to a json file which you can then host internally etc. As there is no contrib/ directory I didn't submit a MR, but feel free to create some place for this and request a MR from me instead. Submittted under MPL as per LICENSE.
+
+See: https://github.com/NUKnightLab/TimelineJS3/issues/398

--- a/contrib/iamamoose/timeline.py.txt
+++ b/contrib/iamamoose/timeline.py.txt
@@ -1,0 +1,53 @@
+# Convert google doc spreadsheet format for timelinejs to json file
+# useful if you want to experiment using google doc but eventually
+# host everything yourself privately.
+
+# Example: go to google docs spreadsheet and do File -> Download As -> CSV (Comma Separated Values)
+# save as timeline.csv, run this, you get a timeline.json out
+#
+# Or look at your google doc ID long string like for example 1xTn9OSdmnxbBtQcKxZYV-xXkKoOpPSu6AUT0LXXszHo
+# wget -qO timeline.csv 'https://docs.google.com/spreadsheets/d/1xTn9OSdmnxbBtQcKxZYV-xXkKoOpPSu6AUT0LXXszHo/pub?output=csv'
+
+import csv
+import json
+
+csvfile = open('timeline.csv','rb')
+outfile = open('timeline.json','w')
+reader = csv.DictReader(csvfile)
+
+data = {}
+events = []
+data['events']=events
+
+# Didn't support 'End Time': '', 'Time': ''
+
+keymap = {'Media': 'media|url', 'Media Caption': 'media|caption', 'Media Thumbnail': 'media|thumbnail',
+          'Month': 'start_date|month', 'Day': 'start_date|day', 'Year': 'start_date|year',
+          'End Month': 'end_date|month', 'End Day': 'end_date|day', 'End Year': 'end_date|year',
+          'Headline': 'text|headline', 'Text': 'text|text',
+          'Group': 'group', 'Display Date': 'display_date' }
+
+for row in reader:
+    event = {}
+    for a in keymap:
+        if row[a]:
+            if '|' in keymap[a]:
+                (x,y)=keymap[a].split("|")
+                if not x in event: event[x]={}
+                event[x][y] = row[a]
+            else:
+                event[keymap[a]] = row[a]                
+
+    if row['Background']:
+        event['background'] = {}
+        if row['Background'].startswith("#"):
+            event['background']['color']=row['Background']
+        else:
+            event['background']['url']=row['Background']
+
+    if (row['Type'] == 'title'):
+        data['title']=event
+    else:
+        events.append(event)
+
+json.dump(data,outfile, sort_keys=True,indent=4)

--- a/source/js/timenav/TL.TimeNav.js
+++ b/source/js/timenav/TL.TimeNav.js
@@ -198,6 +198,7 @@ TL.TimeNav = TL.Class.extend({
 	/*	Groups
 	================================================== */
 	_createGroups: function() {
+		this._groups = [];
 		var group_labels = this.timescale.getGroupLabels();
 
 		if (group_labels) {


### PR DESCRIPTION
re: #331 

_drawTimeline calls triggered by zoom events cause _createGroups to be called. This results in the _groups array growing indefinitely and groups being repeated in the layout

This fix empties the _groups array in _createGroups in order to ensure only one complete set of groups is ever created