### PR TITLE
added text selection to slide content

### DIFF
--- a/source/less/slider/TL.Slide.less
+++ b/source/less/slider/TL.Slide.less
@@ -47,6 +47,7 @@
 			padding-right:100px;
 			position:relative;
 			max-width:100%;
+            user-select: text;
 			.tl-media {
 				//display:table-cell;
 				//vertical-align:middle;


### PR DESCRIPTION
Fix for #593 - text selection enabled for desktop 

Effects on mobile: 

unable to select text on 
- iPhone XR, iPhone 7, iPhone 6s Plus, iPhone 6s, iPhone 5 

able to select text on 
- Lenovo, Google Pixel, Galaxy S7 Edge, Galaxy S6, Lumia 950 (doesn't show what text has been selected), Nexus 6

Swiping doesn't break unless certain text is clicked on for an extended period of time 
Swiping feature does not work on Surface, but able to select text