### PR TITLE
Remove Premature </html> Tag

### DIFF
--- a/source/embed/index.html
+++ b/source/embed/index.html
@@ -26,7 +26,6 @@ html, body {
 <!-- HTML5 shim, for IE6-8 support of HTML elements--><!--[if lt IE 9]>
 <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 </head>
-</html>
 <body>
   <!-- BEGIN Timeline Embed -->
   <div id="timeline-embed"></div>


### PR DESCRIPTION
There was a spurious </html> tag immediately following </head>
in embed/index.html.

Fixes #604.