### PR TITLE
Create accessible contrast theme

### DIFF
--- a/src/less/media/TL.Media.less
+++ b/src/less/media/TL.Media.less
@@ -88,7 +88,7 @@
 /* Credit
 ================================================== */
 .tl-credit {
-	color: #999999;
+	color: @color-text-credit;
 	text-align: right;
 	display: block;
 	margin: 0 auto;

--- a/src/less/slider/TL.SlideNav.less
+++ b/src/less/slider/TL.SlideNav.less
@@ -32,7 +32,6 @@
 	       -ms-hyphens: auto;
 	           hyphens: auto;
 		*/
-		.opacity(15);
 		a {
 			
 		}
@@ -42,6 +41,7 @@
 	}
 	.tl-slidenav-title {
 		margin-top:10px;
+		.opacity(@opacity-slide-nav-title);
 		font-size: @base-font-size-small;
 		line-height: @base-font-size-small;
 		//font-weight: bold;
@@ -49,7 +49,7 @@
 	.tl-slidenav-description {
 		font-size: @base-font-size-small;
 		margin-top:5px;
-		.opacity(0);
+		.opacity(@opacity-slide-nav-desc);
 		small {
 			display:none;
 		}
@@ -126,7 +126,7 @@
 		.opacity(100);
 	}
 	.tl-slidenav-description {
-		.opacity(50);
+		.opacity(@opacity-slide-nav-desc-hover);
 	}
 }
 .tl-slidenav-next:hover {

--- a/src/less/themes/contrast/TL.Theme.Contrast.less
+++ b/src/less/themes/contrast/TL.Theme.Contrast.less
@@ -1,0 +1,16 @@
+/*!
+	Timeline JS 3 
+	
+	Designed and built by Zach Wise for the Northwestern University Knight Lab
+	
+	This Source Code Form is subject to the terms of the Mozilla Public
+	License, v. 2.0. If a copy of the MPL was not distributed with this
+	file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+*/
+
+/* Includes 
+================================================== */
+@import "Variables.less"; 					// Variables (easy way to make style changes) 
+
+@import "../../TL.Timeline.Base.less"; 	// Base Less File

--- a/src/less/themes/contrast/Variables.less
+++ b/src/less/themes/contrast/Variables.less
@@ -1,5 +1,5 @@
 /*	VARIABLES
-	BASE
+	THEME CONTRAST
 ----------------------------------------------------- */
 
 /* ICON PATH
@@ -40,13 +40,13 @@
 @color-theme-split1:			spin(@color-theme, -158);
 @color-theme-split2:			spin(@color-theme, 158);
 
-@color-text: 					lighten(@color-foreground,25);
+@color-text: 					lighten(@color-foreground,1);
 @color-header-text: 			@color-dark;
 
 @color-text-inverted:			darken(@color-background,5);
 @color-header-text-inverted:	@color-background;
 
-@color-text-credit:				#999999;
+@color-text-credit:				#757575;
 
 /* UI COLOR
 ================================================== */
@@ -55,19 +55,19 @@
 @marker-color: 					darken(@ui-background-color,5);
 @marker-outline-color: 			darken(@ui-background-color,10);
 @marker-selected-text-color: 	@color-background;
-@marker-text-color: 			darken(@marker-color,15);
+@marker-text-color: 			darken(@marker-color,50);
 @marker-dot-color: 				darken(@marker-color, 33);
 @marker-dot-hover-color: 		darken(@marker-dot-color, 33);
 
-@marker-color-menubar-button:	darken(@marker-color,15);
+@marker-color-menubar-button:	darken(@marker-color,47);
 
-@minor-ticks-color:				darken(@ui-background-color,20);
-@major-ticks-color:				darken(@minor-ticks-color,30);
+@minor-ticks-color:				darken(@ui-background-color,49);
+@major-ticks-color:				darken(@minor-ticks-color,10);
 
 @minor-ticks-line-color: 		@minor-ticks-color;
 @major-ticks-line-color: 		darken(@minor-ticks-line-color,10);
 
-@brand-color: 					darken(@ui-background-color,15);
+@brand-color: 					darken(@ui-background-color,49);
 
 @era-color-1: 					@color-theme-complement;
 @era-color-2: 					@color-theme-triad1;
@@ -96,8 +96,8 @@
 
 // SlideNav
 @opacity-slide-nav-title:		15;
-@opacity-slide-nav-desc:		 0;
-@opacity-slide-nav-desc-hover:  50;
+@opacity-slide-nav-desc:		62;
+@opacity-slide-nav-desc-hover:  80;
 
 /* Animation
 ================================================== */

--- a/src/less/themes/dark/Variables.less
+++ b/src/less/themes/dark/Variables.less
@@ -8,7 +8,7 @@
 
 /* TYPEFACE
 ================================================== */
-@font-serif: 					"Georgia", Times New Roman, Times, serif;
+@font-serif: 					"Georgia", "Times New Roman", Times, serif;
 @font-sanserif:					"Helvetica Neue", Helvetica, Arial, sans-serif;
 
 @font-main:						@font-sanserif;
@@ -46,6 +46,8 @@
 @color-text-inverted:			darken(@color-dark, 25);
 @color-header-text-inverted:	@color-dark;
 
+@color-text-credit:				#999999;
+
 /* UI COLOR
 ================================================== */
 @ui-background-color:			darken(@color-foreground,50); 
@@ -56,6 +58,8 @@
 @marker-text-color: 			lighten(@marker-color,15);
 @marker-dot-color: 				darken(@ui-background-color, 50);
 @marker-dot-hover-color: 		lighten(@marker-dot-color, 100);
+
+@marker-color-menubar-button:	darken(@marker-color,15);
 
 @minor-ticks-color:				darken(@color-dark,66);
 @major-ticks-color:				lighten(@minor-ticks-color,20);
@@ -89,6 +93,11 @@
 @major-ticks-font-size: 		12px;
 @tick-padding: 					2px;
 @axis-height:					@minor-ticks-font-size + (@major-ticks-font-size*2) + (@tick-padding*2);
+
+// SlideNav
+@opacity-slide-nav-title:		15;
+@opacity-slide-nav-desc:		 0;
+@opacity-slide-nav-desc-hover:  50;
 
 /* Animation
 ================================================== */

--- a/src/less/ui/TL.MenuBar.Button.less
+++ b/src/less/ui/TL.MenuBar.Button.less
@@ -13,7 +13,7 @@
 	display:inline-block;
 	display:block;
 	//color:@color-text;
-	color:darken(@marker-color,15);
+	color:@marker-color-menubar-button;
 	[class^="tl-icon-"], [class*=" tl-icon-"] {
 		
 	}


### PR DESCRIPTION
@NadeemPatel2019 did a lot of research and developed proposed changes to address key places where TimelineJS3 fails WCAG accessibility contrast recommendations and submitted PR #646 with them.

Upon further consideration, it seemed safer to prepare these as a timeline _theme_, so that we could allow people to try it out, and so that we preserve the option to make these available without forcing them on existing timelines.

I'm still getting comfortable with using contrast testing tools, so I'm not 100% certain this addresses all issues, but it provides a baseline.

The themes are not integrated into the webpack dev server flow that runs with `npm start`, so for now, the best way to test is to run `npm run disttest`. This runs a local environment as close as possible to what goes on `cdn.knightlab.com` but locally. Adding `&theme=contrast` to the URL will switch to the new styles.

The variables added to support this are crudely (and specifically) named, so separately from specific contrast (foreground/background color pairs), we may want to consider if there's a more artful, semantic way to name them.