### PR TITLE
Fix calculations for storyslider/nav height

### DIFF
--- a/src/js/timeline/Timeline.js
+++ b/src/js/timeline/Timeline.js
@@ -579,7 +579,7 @@ class Timeline {
         if (Browser.mobile) {
             display_class += " tl-mobile";
             // Set TimeNav Height
-            this.options.timenav_height = this._calculateTimeNavHeight(timenav_height, this.options.timenav_mobile_height_percentage);
+            this.options.timenav_height = this._calculateTimeNavHeight(null, this.options.timenav_mobile_height_percentage);
         } else {
             // Set TimeNav Height
             this.options.timenav_height = this._calculateTimeNavHeight(timenav_height);

--- a/src/less/media/TL.Media.less
+++ b/src/less/media/TL.Media.less
@@ -88,6 +88,7 @@
 /* Credit
 ================================================== */
 .tl-credit {
+	box-sizing: border-box;
 	color: @color-text-credit;
 	text-align: right;
 	display: block;

--- a/src/less/slider/TL.Slide.less
+++ b/src/less/slider/TL.Slide.less
@@ -241,7 +241,6 @@
 
 	.tl-slide {
 		display:block;
-		padding-top:10px;
 		.tl-slide-content-container {
 			display:block;
 			position:static;
@@ -262,8 +261,7 @@
 				-webkit-flex-direction:column-reverse; /* Safari */
 				position:static;
 				height:auto;
-				padding-left:50px;
-				padding-right:50px;
+				padding:10px 50px;
 				.tl-media {
 					position:static;
 					width:100%;


### PR DESCRIPTION
Looking more into it, I found that it has nothing to do with the images loading as I thought from the previous PR. After some debugging, I might have found that the issue is that the `timenav_height_percentage` is not being applied.

### Issue

* * *

| Slide<sup>1</sup> | Time Nav<sup>2</sup> |
| --- | --- |
| <img width="290" alt="issue-1-slide" src="https://user-images.githubusercontent.com/23580535/120469712-01aafa00-c3a3-11eb-97dd-107ba809062c.png"> | <img width="284" alt="issue-2-timenav" src="https://user-images.githubusercontent.com/23580535/120469777-18515100-c3a3-11eb-95e6-36052e764480.png"> |

There seems to be a height problem on the bottom part of the slide<sup>1</sup> or nav<sup>2</sup> on mobile or smaller widths. Setting `timenav_position=top` will cause the slide<sup>1</sup> to not fit its container. And the Time Nav<sup>2</sup> doesn't show the year ruler. Debugging I found that it could be because of the following lines:

```js
if (Browser.mobile) {
    display_class += " tl-mobile";
    // Set TimeNav Height
    this.options.timenav_height = this._calculateTimeNavHeight(timenav_height, this.options.timenav_mobile_height_percentage);
```

Calling `_calculateTimeNavHeight()` with its first parameter `timenav_height` will ignore the second parameter.

Resizing the window/iframe will fix this height problem because it calls `_calculateTimeNavHeight()` with no parameters:

```js
window.addEventListener("resize", function(e) {
    this.updateDisplay();
}.bind(this));
```

### Proposed Solution

* * *

| Slide<sup>1</sup> | Time Nav<sup>2</sup> | Slide<sup>3</sup> | Time Nav<sup>4</sup> |
| --- | --- | --- | --- |
| ![fix-1-slide](https://user-images.githubusercontent.com/23580535/120469892-39b23d00-c3a3-11eb-823f-8883039c5333.png) | ![fix-2-timenav](https://user-images.githubusercontent.com/23580535/120469954-4898ef80-c3a3-11eb-8afe-7babfc85a15c.png) | ![fix-3-credit-padding](https://user-images.githubusercontent.com/23580535/120470003-55b5de80-c3a3-11eb-9533-2431029d99a6.png) | ![fix-4-box-sizing](https://user-images.githubusercontent.com/23580535/120470040-61090a00-c3a3-11eb-834f-04ef5fc6055d.png) |

Call `_calculateTimeNavHeight(null, timenav_height_percentage)` since `timenav_height_percentage` will not be used otherwise because of these lines:

```js
if (timenav_height) {
    height = timenav_height;
} else {
    if (this.options.timenav_height_percentage || timenav_height_percentage) {
        if (timenav_height_percentage) {
            height = Math.round((this.options.height / 100) * timenav_height_percentage);
        } else {
            height = Math.round((this.options.height / 100) * this.options.timenav_height_percentage);
        }

    }
}
```

Doing this made the full image appear on the slide<sup>1</sup> and the ruler appearing on the nav<sup>2</sup>.

To fix the credit under the media, we can move the `padding` inside the scroll container<sup>3</sup>. The credit however seems to have the `width` of its container but has a `margin` increasing its total `width`. Adding a different `box-sizing` includes the `margin` in its `width`<sup>4</sup>.

### Tested URLS

* * *
These are the URLS that I have tested:
- http://127.0.0.1:8080/embed/index.html
- http://127.0.0.1:8080/embed/index.html?timenav_position=top
- http://127.0.0.1:8080/embed/index.html?source=1ZeKRgH6ie-N8P3hCl2NTpLVB_q4t-OfOhBcSwu9dJ2Q
- http://127.0.0.1:8080/embed/index.html?source=1ZeKRgH6ie-N8P3hCl2NTpLVB_q4t-OfOhBcSwu9dJ2Q&timenav_position=top

**Comparison**
- https://cdn.knightlab.com/libs/timeline3/latest/embed/index.html
- https://cdn.knightlab.com/libs/timeline3/latest/embed/index.html&timenav_position=top
- https://cdn.knightlab.com/libs/timeline3/latest/embed/index.html?source=1ZeKRgH6ie-N8P3hCl2NTpLVB_q4t-OfOhBcSwu9dJ2Q
- https://cdn.knightlab.com/libs/timeline3/latest/embed/index.html?source=1ZeKRgH6ie-N8P3hCl2NTpLVB_q4t-OfOhBcSwu9dJ2Q&timenav_position=top

In the comparison links, start out on mobile. Resizing fixes the `height` but not the credit on certain slides with more content. I also found an issue regarding mobile height #675 this PR could fix that, have not tested this though.

Was a bit busy the last few weeks, I have some more time to work on it this week. Let me know if this is going in the right direction or if I missed anything.