### PR TITLE
Remove useless lodash import

### DIFF
--- a/src/js/timenav/TimeEra.js
+++ b/src/js/timenav/TimeEra.js
@@ -5,7 +5,6 @@ import * as Browser from "../core/Browser"
 import { removeClass } from "../dom/DOMUtil";
 import { easeInSpline } from "../animation/Ease";
 import * as DOM from "../dom/DOM"
-import { head } from "lodash";
 
 /**
  * A TimeEra represents a span of time marked along the edge of the time 


### PR DESCRIPTION
First of all thanks for this great library!
While working on a vue3 wrapper around TimelineJS, I got an error with a lodash import.
But in fact it's not even used so let's remove it ;)