### PR TITLE
link_target not considered

### DIFF
--- a/src/js/media/types/Image.js
+++ b/src/js/media/types/Image.js
@@ -29,7 +29,11 @@ export default class Image extends Media {
         if (this.data.link) {
             this._el.content_link = this.domCreate("a", "", this._el.content);
             this._el.content_link.href = this.data.link;
-            this._el.content_link.target = "_blank";
+            if (this.data.link_target) {
+                this._el.content_link.target = this.data.link_target;
+            } else {
+                this._el.content_link.target = "_blank";
+            }
             this._el.content_link.setAttribute('rel', 'noopener');
             this._el.content_item = this.domCreate("img", image_class, this._el.content_link);
         } else {


### PR DESCRIPTION
[Docs](http://timeline.knightlab.com/docs/json-format.html#json-media) state that when offering a `link` for a media object,  `link_target` could be used to override default value (`_blank`). This PR makes this happen.