### PR TITLE
Uses `import` in place of `require` for Less file.

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,4 @@
-require('../less/TL.Timeline.less')
+import "../less/TL.Timeline.less"
 export { Timeline }
 from "./timeline/Timeline"
 export { parseGoogleSpreadsheetURL }


### PR DESCRIPTION
Hi!

We are using [vite](https://vitejs.dev/) to build a project that imports TimelineJS, and it cannot handle the `require` statement for the `less/TL.Timeline.less` file. However, it does fine with an `import` statement, and this doesn't appear to cause any issues with a webpack build. (We use webpack in a separate downstream project and it builds fine.)

I'm not 100% certain of the consequences of doing this, but it should only affect users who are importing files from `src/` and not using the files in `dist/`.

I'd usually open an issue (without a pull request) first, but this felt like the easiest way to explain the issue and what may be the fix. Thank you for your time!