### PR TITLE
Fix for dropbox.com audio and video files 

### DIFF
--- a/src/js/core/Util.js
+++ b/src/js/core/Util.js
@@ -521,7 +521,7 @@ export function linkify(text, targets, is_touch) {
  * as a direct image link. Some services have predictable transformations we can use rather than explain to people
  * this subtlety.
  */
-export function transformImageURL(url) {
+export function transformMediaURL(url) {
     return url.replace(/(.*)www.dropbox.com\/(.*)/, '$1dl.dropboxusercontent.com/$2')
 }
 

--- a/src/js/media/types/Audio.js
+++ b/src/js/media/types/Audio.js
@@ -1,9 +1,11 @@
 import { Media } from "../Media";
+import { transformImageURL } from "../../core/Util";
 import * as Browser from "../../core/Browser"
 import { trace } from "../../core/Util";
 
 export default class Audio extends Media {
     _loadMedia() {
+    
         // Loading Message
         this.loadingMessage();
 
@@ -17,6 +19,10 @@ export default class Audio extends Media {
     }
 
     createMedia() {
+        //Transform URL for Dropbox
+        var url = transformImageURL(this.data.url),
+            self = this; 
+
         var self = this,
             audio_class = "tl-media-item tl-media-audio tl-media-shadow";
 
@@ -39,7 +45,7 @@ export default class Audio extends Media {
             self.onMediaLoaded();
         });
 
-        this._el.source_item.src = this.data.url;
+        this._el.source_item.src = url;
         this._el.source_item.type = this._getType(this.data.url, this.data.mediatype.match_str);
         this._el.content_item.innerHTML += "Your browser doesn't support HTML5 audio with " + this._el.source_item.type;
         this.player_element = this._el.content_item

--- a/src/js/media/types/Audio.js
+++ b/src/js/media/types/Audio.js
@@ -1,5 +1,5 @@
 import { Media } from "../Media";
-import { transformImageURL } from "../../core/Util";
+import { transformMediaURL } from "../../core/Util";
 import * as Browser from "../../core/Browser"
 import { trace } from "../../core/Util";
 
@@ -20,7 +20,7 @@ export default class Audio extends Media {
 
     createMedia() {
         //Transform URL for Dropbox
-        var url = transformImageURL(this.data.url),
+        var url = transformMediaURL(this.data.url),
             self = this; 
 
         var self = this,

--- a/src/js/media/types/Image.js
+++ b/src/js/media/types/Image.js
@@ -1,5 +1,5 @@
 import { Media } from "../Media"
-import { unhtmlify, transformImageURL } from "../../core/Util"
+import { unhtmlify, transformMediaURL } from "../../core/Util"
 import * as Browser from "../../core/Browser"
 
 export default class Image extends Media {
@@ -57,7 +57,7 @@ export default class Image extends Media {
     }
 
     getImageURL(w, h) {
-        return transformImageURL(this.data.url);
+        return transformMediaURL(this.data.url);
     }
 
     _updateMediaDisplay(layout) {

--- a/src/js/media/types/PDF.js
+++ b/src/js/media/types/PDF.js
@@ -1,11 +1,11 @@
 import { Media } from "../Media";
-import { transformImageURL } from "../../core/Util";
+import { transformMediaURL } from "../../core/Util";
 import * as Browser from "../../core/Browser"
 
 export default class PDF extends Media {
 
     _loadMedia() {
-        var url = transformImageURL(this.data.url),
+        var url = transformMediaURL(this.data.url),
             self = this;
 
         // Create Dom element

--- a/src/js/media/types/Video.js
+++ b/src/js/media/types/Video.js
@@ -1,5 +1,6 @@
 import { Media } from "../Media";
 import * as Browser from "../../core/Browser"
+import { transformImageURL } from "../../core/Util";
 
 export default class Video extends Media {
     _loadMedia() {
@@ -16,6 +17,10 @@ export default class Video extends Media {
     }
 
     createMedia() {
+        //Transform URL for Dropbox
+        var url = transformImageURL(this.data.url),
+            self = this;
+
         var self = this,
             video_class = "tl-media-item tl-media-video tl-media-shadow";
 
@@ -38,7 +43,7 @@ export default class Video extends Media {
             self.onMediaLoaded();
         });
 
-        this._el.source_item.src = this.data.url;
+        this._el.source_item.src = url;
         this._el.source_item.type = this._getType(this.data.url, this.data.mediatype.match_str);
         this._el.content_item.innerHTML += "Your browser doesn't support HTML5 video with " + this._el.source_item.type;
         this.player_element = this._el.content_item

--- a/src/js/media/types/Video.js
+++ b/src/js/media/types/Video.js
@@ -1,6 +1,6 @@
 import { Media } from "../Media";
 import * as Browser from "../../core/Browser"
-import { transformImageURL } from "../../core/Util";
+import { transformMediaURL } from "../../core/Util";
 
 export default class Video extends Media {
     _loadMedia() {
@@ -18,7 +18,7 @@ export default class Video extends Media {
 
     createMedia() {
         //Transform URL for Dropbox
-        var url = transformImageURL(this.data.url),
+        var url = transformMediaURL(this.data.url),
             self = this;
 
         var self = this,


### PR DESCRIPTION
#719 Fixed the issue for **dropbox.com** links not working for audio and video files. Seems only consistent to have the same behaviour across all types. Used the fix from the PDF class that uses the transformImageURL function from Util. 

Should the function get renamed for clarity?