### PR TITLE
Add translations for Norwegian (bokmål) and Norwegian (nynorsk)

### DIFF
--- a/src/js/language/locale/nb.json
+++ b/src/js/language/locale/nb.json
@@ -1,0 +1,76 @@
+{
+    "lang": "nb", 
+    "date": {
+        "month_abbr": [
+            "Jan.", 
+            "Feb.", 
+            "Mars", 
+            "Apr.", 
+            "Mai", 
+            "Juni", 
+            "Juli", 
+            "Aug.", 
+            "Sep.", 
+            "Okt.", 
+            "Nov.", 
+            "Des."
+        ], 
+        "day_abbr": [
+            "Søn.", 
+            "Man.", 
+            "Tir.", 
+            "Ons.", 
+            "Tor.", 
+            "Fre.", 
+            "Lør."
+        ], 
+        "day": [
+            "Søndag", 
+            "Mandag", 
+            "Tirsdag", 
+            "Onsdag", 
+            "Torsdag", 
+            "Fredag", 
+            "Lørdag"
+        ], 
+        "month": [
+            "Januar", 
+            "Februar", 
+            "Mars", 
+            "April", 
+            "Mai", 
+            "Juni", 
+            "Juli", 
+            "August", 
+            "September", 
+            "Oktober", 
+            "November", 
+            "Desember"
+        ]
+    }, 
+    "api": {
+        "wikipedia": "no"
+    }, 
+    "messages": {
+        "loading": "Laster", 
+        "contract_timeline": "Krymp tidslinje", 
+        "return_to_title": "Tilbake til tittel", 
+        "wikipedia": "Fra Wikipedia, den frie encyklopedi", 
+        "loading_content": "Laster innhold", 
+        "expand_timeline": "Utvid tidslinje", 
+        "loading_timeline": "Laster tidslinje... ",
+        "swipe_to_navigate": "Sveip for å navigere<br><span class='tl-button'>OK</span>"
+    }, 
+    "dateformats": {
+        "full_long": "dddd',' d. mmm',' yyyy 'kl.' HH:MM", 
+        "full_short": "d. mmm", 
+        "full": "d. mmmm',' yyyy", 
+        "month_short": "mmm", 
+        "time_no_seconds_small_date": "HH:MM'<br/><small>'d. mmmm',' yyyy'</small>'", 
+        "month": "mmmm yyyy", 
+        "time_no_seconds_short": "HH:MM", 
+        "time_short": "HH:MM:ss", 
+        "year": "yyyy", 
+        "full_long_small_date": "HH:MM'<br/><small>'dddd',' d. mmm',' yyyy'</small>'"
+    }
+}

--- a/src/js/language/locale/nn.json
+++ b/src/js/language/locale/nn.json
@@ -1,0 +1,76 @@
+{
+    "lang": "nn", 
+    "date": {
+        "month_abbr": [
+            "Jan.", 
+            "Feb.", 
+            "Mars", 
+            "Apr.", 
+            "Mai", 
+            "Juni", 
+            "Juli", 
+            "Aug.", 
+            "Sep.", 
+            "Okt.", 
+            "Nov.", 
+            "Des."
+        ], 
+        "day_abbr": [
+            "Søn.", 
+            "Man.", 
+            "Tir.", 
+            "Ons.", 
+            "Tor.", 
+            "Fre.", 
+            "Lau."
+        ], 
+        "day": [
+            "Søndag", 
+            "Mandag", 
+            "Tirsdag", 
+            "Onsdag", 
+            "Torsdag", 
+            "Fredag", 
+            "Laurdag"
+        ], 
+        "month": [
+            "Januar", 
+            "Februar", 
+            "Mars", 
+            "April", 
+            "Mai", 
+            "Juni", 
+            "Juli", 
+            "August", 
+            "September", 
+            "Oktober", 
+            "November", 
+            "Desember"
+        ]
+    }, 
+    "api": {
+        "wikipedia": "nn"
+    }, 
+    "messages": {
+        "loading": "Lastar", 
+        "contract_timeline": "Krymp tidslinje", 
+        "return_to_title": "Tilbake til tittel", 
+        "wikipedia": "Frå Wikipedia, dete frie oppslagsverket", 
+        "loading_content": "Lastar innhold", 
+        "expand_timeline": "Utvid tidslinje", 
+        "loading_timeline": "Lastar tidslinje... ",
+        "swipe_to_navigate": "Sveip for å navigere<br><span class='tl-button'>OK</span>"
+    }, 
+    "dateformats": {
+        "full_long": "dddd',' d. mmm',' yyyy 'kl.' HH:MM", 
+        "full_short": "d. mmm", 
+        "full": "d. mmmm',' yyyy", 
+        "month_short": "mmm", 
+        "time_no_seconds_small_date": "HH:MM'<br/><small>'d. mmmm',' yyyy'</small>'", 
+        "month": "mmmm yyyy", 
+        "time_no_seconds_short": "HH:MM", 
+        "time_short": "HH:MM:ss", 
+        "year": "yyyy", 
+        "full_long_small_date": "HH:MM'<br/><small>'dddd',' d. mmm',' yyyy'</small>'"
+    }
+}

--- a/src/js/language/locale/nn.json
+++ b/src/js/language/locale/nn.json
@@ -17,8 +17,8 @@
         ], 
         "day_abbr": [
             "Søn.", 
-            "Man.", 
-            "Tir.", 
+            "Mån.", 
+            "Tys.", 
             "Ons.", 
             "Tor.", 
             "Fre.", 
@@ -26,7 +26,7 @@
         ], 
         "day": [
             "Søndag", 
-            "Mandag", 
+            "Måndag", 
             "Tysdag", 
             "Onsdag", 
             "Torsdag", 

--- a/src/js/language/locale/nn.json
+++ b/src/js/language/locale/nn.json
@@ -55,7 +55,7 @@
         "loading": "Lastar", 
         "contract_timeline": "Krymp tidslinje", 
         "return_to_title": "Tilbake til tittel", 
-        "wikipedia": "Frå Wikipedia, dete frie oppslagsverket", 
+        "wikipedia": "Frå Wikipedia, det frie oppslagsverket", 
         "loading_content": "Lastar innhold", 
         "expand_timeline": "Utvid tidslinje", 
         "loading_timeline": "Lastar tidslinje... ",

--- a/src/js/language/locale/nn.json
+++ b/src/js/language/locale/nn.json
@@ -27,7 +27,7 @@
         "day": [
             "Søndag", 
             "Mandag", 
-            "Tirsdag", 
+            "Tysdag", 
             "Onsdag", 
             "Torsdag", 
             "Fredag", 

--- a/website/templates/_make.html
+++ b/website/templates/_make.html
@@ -121,7 +121,8 @@
                                                         <option value="nl" data-lang="Dutch">Nederlands</option>
                                                         <option value="ne" data-lang="Nepali">नेपाली</option>
                                                         <option value="ja" data-lang="Japanese">日本語</option>
-                                                        <option value="no" data-lang="Norwegian">Norsk</option>
+                                                        <option value="nb" data-lang="Norwegian - Bokmal">Norsk (bokmål)</option>
+                                                        <option value="nn" data-lang="Norwegian - Nynorsk">Norsk (nynorsk)</option>
                                                         <option value="th" data-lang="Thai">ภาษาไทย</option>
                                                         <option value="pl" data-lang="Polish">Polski</option>
                                                         <option value="pt" data-lang="Portuguese">Português</option>


### PR DESCRIPTION
The ISO 639-1 locale code for Norwegian (bokmål) is not `no` as is used in today's Timeline, but rather `nb`. This PR does not delete the `no.json` file, because `no` and `nb` are de facto interchangeable and both will not always be set.

This PR also adds translations for [Norwegian nynorsk](https://en.wikipedia.org/wiki/Nynorsk). 