### PR TITLE
Added tab stop that encompasses the `Timeline`

### DIFF
--- a/src/js/timeline/Timeline.js
+++ b/src/js/timeline/Timeline.js
@@ -193,6 +193,7 @@ class Timeline {
 
         // Apply base class to container
         addClass(this._el.container, 'tl-timeline');
+        this._el.container.setAttribute('tabindex', '0');
 
         if (this.options.is_embed) {
             addClass(this._el.container, 'tl-timeline-embed');


### PR DESCRIPTION
## This PR fulfills the issue - https://github.com/NUKnightLab/TimelineJS3/issues/753

With the `tabindex=0` the users will be able to tab to the `Timeline` component and see the explicit outline on it when they get there