### PR TITLE
Fixed appearing of the `Slidenav` arrows on mobile

### DIFF
--- a/src/js/slider/SlideNav.js
+++ b/src/js/slider/SlideNav.js
@@ -93,12 +93,17 @@ export class SlideNav {
 	_update(d) {
 		// update data
 		this.data = mergeData(this.data, d);
-		
-		// Title
-		this._el.title.innerHTML = unlinkify(this.data.title);
-		
-		// Date
-		this._el.description.innerHTML	= unlinkify(this.data.date);
+
+        // Title
+        const title = unlinkify(this.data.title);
+        this._el.title.innerHTML = title;
+
+        // Date
+        const date = unlinkify(this.data.date);
+        this._el.description.innerHTML = date;
+
+        // Alternative text
+        this._el.container.setAttribute('aria-label', `${this.options.direction}, ${title}, ${date}`)
 	}
 	
 	_initLayout () {

--- a/src/js/slider/SlideNav.js
+++ b/src/js/slider/SlideNav.js
@@ -39,7 +39,7 @@ export class SlideNav {
 		mergeData(this.data, data);
 		
 		
-		this._el.container = DOM.create("div", "tl-slidenav-" + this.options.direction);
+		this._el.container = DOM.create("button", "tl-slidenav-" + this.options.direction);
 		
 		if (Browser.mobile) {
 			this._el.container.setAttribute("ontouchstart"," ");

--- a/src/js/slider/StorySlider.js
+++ b/src/js/slider/StorySlider.js
@@ -326,7 +326,7 @@ export class StorySlider {
     showNav(nav_obj, show) {
 
         if (this.options.width <= 500 && Browser.mobile) {
-
+            nav_obj.hide();
         } else {
             if (show) {
                 nav_obj.show();

--- a/src/less/slider/TL.SlideNav.less
+++ b/src/less/slider/TL.SlideNav.less
@@ -8,9 +8,17 @@
 	top: 45%;
 	z-index:10;
 	cursor:pointer;
-	
-	.tl-slidenav-content-container {
-		height:200px;
+    padding: 0;
+    outline-offset:5px;
+    background-color: transparent;
+    border: none;
+    text-align: inherit;
+    text-transform: inherit;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+
+    .tl-slidenav-content-container {
 		width:100px;
 		position:absolute;
 	}
@@ -121,23 +129,29 @@
 
 /* NAVIGATION HOVER
 ================================================== */
-.tl-slidenav-previous:hover, .tl-slidenav-next:hover {
-	.tl-slidenav-title {
-		.opacity(100);
-	}
-	.tl-slidenav-description {
-		.opacity(@opacity-slide-nav-desc-hover);
-	}
+.tl-slidenav-previous, .tl-slidenav-next {
+    &:hover, &:focus-visible {
+        .tl-slidenav-title {
+            .opacity(100);
+        }
+        .tl-slidenav-description {
+            .opacity(@opacity-slide-nav-desc-hover);
+        }
+    }
 }
-.tl-slidenav-next:hover {
-	.tl-slidenav-icon {
-        margin-left: 100 - 20px;
-	}
+.tl-slidenav-next {
+    &:hover, &:focus-visible {
+        .tl-slidenav-icon {
+            margin-left: 100 - 20px;
+        }
+    }
 }
-.tl-slidenav-previous:hover {
-	.tl-slidenav-icon {
-		margin-left: -4px;
-	}
+.tl-slidenav-previous {
+    &:hover, &:focus-visible {
+        .tl-slidenav-icon {
+            margin-left: -4px;
+        }
+    }
 }
 
 // Mobile, iPhone and skinny
@@ -165,17 +179,21 @@
 			.opacity(33);
 		}
 	}
-	.tl-slidenav-next:hover {
-		.tl-slidenav-icon {
-	       margin-left:32 - 20px;
-		   .opacity(100);
-		}
+	.tl-slidenav-next {
+        &:hover, &:focus-visible {
+            .tl-slidenav-icon {
+                margin-left:32 - 20px;
+                .opacity(100);
+            }
+        }
 	}
-	.tl-slidenav-previous:hover {
-		.tl-slidenav-icon {
-			margin-left: -4px;
-			.opacity(100);
-		}
+	.tl-slidenav-previous {
+        &:hover, &:focus-visible {
+            .tl-slidenav-icon {
+                margin-left: -4px;
+                .opacity(100);
+            }
+        }
 	}
 	
 }
@@ -184,6 +202,7 @@
 
 .tl-layout-landscape.tl-mobile {
 	.tl-slidenav-next:hover {
+
 		right: 70px;
 		.tl-slidenav-icon {
 	       margin-left:32 - 24px;

--- a/src/less/slider/TL.SlideNav.less
+++ b/src/less/slider/TL.SlideNav.less
@@ -219,20 +219,24 @@
             }
         }
     }
-	.tl-slidenav-previous:hover {
-		.tl-slidenav-icon {
-			//margin-left: 0px;
-			margin-left: 100 - 20px;
-			.opacity(100);
-		}
-	}
-	.tl-slidenav-previous:active {
-		.tl-slidenav-icon {
-		   .opacity(100);
-		   margin-left: -4px;
-		}
-	}
+    .tl-slidenav-previous {
+        &:hover {
+            /**
+            * On mobile the hover state stays on the button after the click
+            * Show the default margin as before the click
+            */
+            .tl-slidenav-icon {
+                margin-left: 0px;
+                .opacity(100);
+            }
+        }
 
+        &:active {
+            .tl-slidenav-icon {
+                margin-left: -4px;
+            }
+        }
+    }
 }
 
 .tl-layout-portrait.tl-mobile {

--- a/src/less/slider/TL.SlideNav.less
+++ b/src/less/slider/TL.SlideNav.less
@@ -201,20 +201,24 @@
 
 
 .tl-layout-landscape.tl-mobile {
-	.tl-slidenav-next:hover {
+    .tl-slidenav-next {
+        &:hover {
+            /**
+            * On mobile the hover state stays on the button after the click
+            * Show the default margin as before the click
+            */
+            .tl-slidenav-icon {
+                margin-left: 100 - 24px;
+                .opacity(100);
+            }
+        }
 
-		right: 70px;
-		.tl-slidenav-icon {
-	       margin-left:32 - 24px;
-		   .opacity(100);
-		}
-	}
-	.tl-slidenav-next:active {
-		.tl-slidenav-icon {
-			margin-left: 0px;
-		   .opacity(100);
-		}
-	}
+        &:active {
+            .tl-slidenav-icon {
+                margin-left: 100 - 20px;
+            }
+        }
+    }
 	.tl-slidenav-previous:hover {
 		.tl-slidenav-icon {
 			//margin-left: 0px;


### PR DESCRIPTION
## This PR fulfills the issue - https://github.com/NUKnightLab/TimelineJS3/issues/772

### Before approaching this PR, some previous PRs need to be reviewed and merged first - https://github.com/NUKnightLab/TimelineJS3/pull/749
---

Previously the arrows were always on the screen when a user turns their phone to landscape mode for the first time. Now they will hide when the user has a viewport of less than 500px and he's using a mobile

---

Fixed randomly jumping sideways arrows in the landscape mode. Now their behavior matches the desktop
![Peek 2022-07-04 17-51](https://user-images.githubusercontent.com/68850090/177191832-e74c506c-b98d-4354-ab4b-ade4f4e3701c.gif)
 the desktop
![Peek 2022-07-04 17-59](https://user-images.githubusercontent.com/68850090/177191831-0aa27952-8ffa-4b8b-a941-1d35ab9fed8d.gif)



