### PR TITLE
Revert "Reading order improvements"

### DIFF
--- a/src/embed/index.html
+++ b/src/embed/index.html
@@ -14,8 +14,8 @@
     <link rel="icon" type="image/png" href="https://cdn.knightlab.com/libs/orangeline/latest/assets/favicons/favicon-16x16.png" sizes="16x16">
     <link rel="manifest" href="https://cdn.knightlab.com/libs/orangeline/latest/assets/favicons/manifest.json">
     <link rel="mask-icon" href="https://cdn.knightlab.com/libs/orangeline/latest/assets/favicons/safari-pinned-tab.svg" color="#5bbad5">
-    <!--
-      If we want to support loading different versions of timeline like we used to,
+    <!-- 
+      If we want to support loading different versions of timeline like we used to, 
       this isn't good enough. We used that to get the non-minimized version, for debugging,
       but now maybe sourcemaps are a better alternative?
     -->

--- a/src/js/media/types/Text.js
+++ b/src/js/media/types/Text.js
@@ -9,7 +9,6 @@ export class Text {
 			container: { },
 			content_container: { },
 			content: { },
-            headline_container: { },
 			headline: { },
 			date: { }
 		}
@@ -25,54 +24,54 @@ export class Text {
 		}
 
 		setData(this, data); // override defaults
-
+		
 		// Merge Options
 		mergeData(this.options, options);
-
+		
 		this._el.container = DOM.create("div", "tl-text");
 		this._el.container.id = this.data.unique_id;
-
+		
 		this._initLayout();
-
+		
 		if (add_to_container) {
 			add_to_container.appendChild(this._el.container);
 		};
-
+		
 	}
-
+	
 	/*	Adding, Hiding, Showing etc
 	================================================== */
 	show() {
-
+		
 	}
-
+	
 	hide() {
-
+		
 	}
-
+	
 	addTo(container) {
 		container.appendChild(this._el.container);
 		//this.onAdd();
 	}
-
+	
 	removeFrom(container) {
 		container.removeChild(this._el.container);
 	}
-
+	
 	headlineHeight() {
 		return this._el.headline.offsetHeight + 40;
 	}
-
+	
 	addDateText(str) {
 		this._el.date.innerHTML = str;
 	}
-
+	
 	/*	Events
 	================================================== */
 	onLoaded() {
 		this.fire("loaded", this.data);
 	}
-
+	
 	onAdd() {
 		this.fire("added", this.data);
 	}
@@ -80,27 +79,26 @@ export class Text {
 	onRemove() {
 		this.fire("removed", this.data);
 	}
-
+	
 	/*	Private Methods
 	================================================== */
 	_initLayout() {
-
+		
 		// Create Layout
 		this._el.content_container = DOM.create("div", "tl-text-content-container", this._el.container);
-		this._el.headline_container = DOM.create("div", "tl-text-headline-container", this._el.content_container);
-
-        // Headline
-        if (this.data.headline != "") {
-            var headline_class = "tl-headline";
-            if (this.options.title) {
-                headline_class = "tl-headline tl-headline-title";
-            }
-            this._el.headline = DOM.create("h2", headline_class, this._el.headline_container);
-            this._el.headline.innerHTML		= this.data.headline;
-        }
-
-        // Date
-		this._el.date = DOM.create("h3", "tl-headline-date", this._el.headline_container);
+		
+		// Date
+		this._el.date = DOM.create("h3", "tl-headline-date", this._el.content_container);
+		
+		// Headline
+		if (this.data.headline != "") {
+			var headline_class = "tl-headline";
+			if (this.options.title) {
+				headline_class = "tl-headline tl-headline-title";
+			}
+			this._el.headline = DOM.create("h2", headline_class, this._el.content_container);
+			this._el.headline.innerHTML		= this.data.headline;
+		}
 
 		// Text
 		if (this.data.text != "") {

--- a/src/js/slider/Slide.js
+++ b/src/js/slider/Slide.js
@@ -320,8 +320,8 @@ export class Slide {
             this._text.addTo(this._el.content);
             this._media.addTo(this._el.content);
         } else if (this.has.text && this.has.media) {
-            this._text.addTo(this._el.content);
             this._media.addTo(this._el.content);
+            this._text.addTo(this._el.content);
         } else if (this.has.text || this.has.headline) {
             addClass(this._el.container, 'tl-slide-text-only');
             this._text.addTo(this._el.content);

--- a/src/less/media/types/TL.Media.Text.less
+++ b/src/less/media/types/TL.Media.Text.less
@@ -19,11 +19,6 @@
 		.tl-text-content{
 
 		}
-        .tl-text-headline-container {
-            display: flex;
-            flex-direction:column-reverse;
-            -webkit-flex-direction:column-reverse; /* Safari */
-        }
 	}
 	h2.tl-headline-title, h2.tl-headline {
 		margin-top:0;

--- a/src/less/slider/TL.Slide.less
+++ b/src/less/slider/TL.Slide.less
@@ -42,8 +42,7 @@
 		.tl-slide-content {
 			//width:100%;
 			display:table;
-            vertical-align:middle;
-			direction:rtl; // Text content needs to be read before the media
+			vertical-align:middle;
 			padding-left:100px;
 			padding-right:100px;
 			position:relative;
@@ -248,8 +247,10 @@
 			position:static;
 			height:auto;
 			height:100%;
+			//vertical-align:baseline;
 			display: -webkit-flex; /* Safari */
 			display: flex;
+			//flex-direction:column-reverse;
 			align-items: center;
 			-webkit-align-items: center; /* Safari 7.0+ */
 			.tl-slide-content {
@@ -257,8 +258,8 @@
 
     			display: -webkit-flex; /* Safari */
 				display: flex;
-				flex-direction:column;
-				-webkit-flex-direction:column; /* Safari */
+				flex-direction:column-reverse;
+				-webkit-flex-direction:column-reverse; /* Safari */
 				position:static;
 				height:auto;
 				padding-left:50px;


### PR DESCRIPTION
Reverts NUKnightLab/TimelineJS3#747

I found that the change contains a bug. Especially the `direction:rtl` added to the `div` tag. The direction will be inherited in the children's elements and the dots will appear at the start of the sentences, not at the end of 'em. 
![image](https://user-images.githubusercontent.com/68850090/180373092-dc3b62fb-5988-4ac6-aa2e-29d9a07f98e0.png)

Anyway, that specific line needs to be removed for now, and we have to figure out a different solution for reading order