### PR TITLE
Added `prepublishOnly` to not forget build `dist`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
         "start": "npx webpack serve --open --config webpack.dev.js",
         "stage": "npm run dist && node tasks/stage.js",
         "stage_latest": "npm run dist && node tasks/stage.js latest",
-        "stage_dev": "npm run dist && node tasks/stage.js dev"
+        "stage_dev": "npm run dist && node tasks/stage.js dev",
+        "prepublishOnly": "npm run dist"
     },
     "contributors": [{
             "name": "Zach Wise",


### PR DESCRIPTION
It would be extremely convenient to have a script that will build the library before it'll be published to NPM. Because we already stumbled on the "we forgot to build the `dist` before" publishing a few times during the custom fork development