### PR TITLE
Fixed white screen of death which appears on iPhone 13 in Safari

### DIFF
--- a/src/less/slider/TL.Slide.less
+++ b/src/less/slider/TL.Slide.less
@@ -245,7 +245,6 @@
 		.tl-slide-content-container {
 			display:block;
 			position:static;
-			height:auto;
 			height:100%;
 			//vertical-align:baseline;
 			display: -webkit-flex; /* Safari */
@@ -265,7 +264,6 @@
 				padding-left:50px;
 				padding-right:50px;
 				.tl-media {
-					position:static;
 					width:100%;
 					height:auto;
 					float: none;


### PR DESCRIPTION
## This PR fulfills the issue - https://github.com/NUKnightLab/TimelineJS3/issues/785

After countless hours of debugging and bisecting what code part can be responsible for the white screen of death... I finally found what breaks the Safari. **_It's the one line of CSS which is removed in this PR._** 

Somehow, overriding the `position:relative` with `position:static` makes the Safari crumble. After that line was removed, the component started to work perfectly fine.

---

Luckily, I think we can safely remove the `positon:static` because higher in the file `.tl-media` has the `position:relative`. Therefore any element with the `.tl-media` class will be laid out just like any static element.
[Docs](https://www.w3.org/wiki/CSS_static_and_relative_positioning?viewType=Print&viewClass=Print#:~:text=text%2Dalign%20property.-,Relative%20positioning,-Relative%20positioning%20is)