### PR TITLE
Fixed overriding of the `box-sizing` CSS prop for the `.tl-slide-content`

### DIFF
--- a/src/less/slider/TL.Slide.less
+++ b/src/less/slider/TL.Slide.less
@@ -49,6 +49,10 @@
 			position:relative;
 			max-width:100%;
 			user-select: text;
+            -webkit-box-sizing: content-box;
+            -moz-box-sizing: content-box;
+            box-sizing: content-box;
+
 			.tl-media {
                 grid-area: media;
 				position:relative;


### PR DESCRIPTION
Added explicit `box-sizing: content-box;` for the `.tl-slide-content`. It's required to position the slide content properly if the consuming app contains a very popular `box-sizing: border-box;` pattern: 
```css
* { box-sizing: border-box; }
```

Without the explicit `box-sizing: content-box;` the content will be shifted to the left and the paddings added [on these lines](https://github.com/NUKnightLab/TimelineJS3/blob/master/src/js/slider/Slide.js#L135-L163) wouldn't work correctly: 
![image](https://user-images.githubusercontent.com/68850090/182098252-72014c62-1b1d-405e-b083-50f9ea036558.png)
It's because the padding will be included in the width of the `.tl-slide-content`.

But with the explicit `box-sizing: content-box;` everything will work as expected again: 
![image](https://user-images.githubusercontent.com/68850090/182098734-e79f03b0-b679-4d58-a2f0-fe73643a5c3e.png)

