### PR TITLE
suggestion for issue 676

### DIFF
--- a/src/js/timeline/Timeline.js
+++ b/src/js/timeline/Timeline.js
@@ -45,6 +45,22 @@ function make_keydown_handler(timeline) {
     }
 }
 
+if (typeof makeHash !== 'function') {
+    function makeHash(id) {
+        var hash = "#" + "event-" + id.toString();
+        return hash;
+    }
+}
+
+if (typeof idFromHash !== 'function') {
+    function idFromHash(hash) {
+        if (!hash.startsWith("#event")) {
+            return null;
+        }
+        return hash.replace("#event-", "");
+    }
+}
+
 /**
  * Primary entry point for using TimelineJS.
  * @constructor
@@ -791,15 +807,17 @@ class Timeline {
                 this.goTo(this.options.start_at_slide);
             }
             if (this.options.hash_bookmark) {
-                if (window.location.hash != "") {
-                    this.goToId(window.location.hash.replace("#event-", ""));
+                let hash = window.location.hash;
+                if (hash != "") {
+                    this.goToId(idFromHash(hash));
                 } else {
                     this._updateHashBookmark(this.current_id);
                 }
                 let the_timeline = this;
                 window.addEventListener('hashchange', function() {
-                    if (window.location.hash.indexOf('#event-') == 0) {
-                        the_timeline.goToId(window.location.hash.replace("#event-", ""));
+                    let id = idFromHash(hash);
+                    if (id !== null) {
+                        the_timeline.goToId(id);
                     }
                 }, false);
             }
@@ -810,9 +828,9 @@ class Timeline {
     // Update hashbookmark in the url bar
     _updateHashBookmark(id) {
         if (id) { // TODO: validate the id...
-            var hash = "#" + "event-" + id.toString();
+            var hash = makeHash(id);
             window.history.replaceState(null, "Browsing TimelineJS", hash);
-            this.fire("hash_updated", { unique_id: this.current_id, hashbookmark: "#" + "event-" + id.toString() }, this);
+            this.fire("hash_updated", { unique_id: this.current_id, hashbookmark: hash }, this);
         }
     }
 


### PR DESCRIPTION
Hi Joe. Is this sort of thing OK for #676 ?
(jest tests pass)

I'd want deterministic logic that can override defaults.

Scenarios (all in the same timeline)

1. "headline": "Report: turns out Einstein was wrong" 
could have a hash of "#report-turns-out-einstein-was-wrong"

2. "headline": "Opinion: Soccer matches ending in nil-nil leaves fans bitter" 
could have a hash of "#opinion-soccer-matches-ending-in-nil-nil-leaves-fans-bitter"

3. "headline": "Eurovision song contest won by Ukraine" 
could have a hash of "#event-eurovision-song-contest-won-by -ukraine"

To achieve that I'd have deterministic logic to look for "Report" and "Opinion" at the start of a **headline** for custom hashes, but default to "Event" (as now) for situations where I can't pick out either of those two alternates.




