### PR TITLE
Add `type="button"` to dynamically created button elements.

### DIFF
--- a/src/js/dom/DOM.js
+++ b/src/js/dom/DOM.js
@@ -19,6 +19,12 @@ function create(tagName, className, container) {
 	return el;
 }
 
+function createButton(className, container) {
+	var el = create('button', className, container);
+	el.type = 'button';
+	return el;
+}
+
 function createText(content, container) {
 	var el = document.createTextNode(content);
 	if (container) {
@@ -78,4 +84,4 @@ let TRANSFORM = testProp(['transformProperty', 'WebkitTransform', 'OTransform', 
 let TRANSLATE_OPEN = 'translate' + (Browser.webkit3d ? '3d(' : '(')
 let TRANSLATE_CLOSE = Browser.webkit3d ? ',0)' : ')'
 
-export { get, create, getPosition }
+export { get, create, createButton, getPosition }

--- a/src/js/slider/SlideNav.js
+++ b/src/js/slider/SlideNav.js
@@ -39,7 +39,7 @@ export class SlideNav {
 		mergeData(this.data, data);
 		
 		
-		this._el.container = DOM.create("button", "tl-slidenav-" + this.options.direction);
+		this._el.container = DOM.createButton("tl-slidenav-" + this.options.direction);
 		
 		if (Browser.mobile) {
 			this._el.container.setAttribute("ontouchstart"," ");

--- a/src/js/ui/MenuBar.js
+++ b/src/js/ui/MenuBar.js
@@ -154,10 +154,10 @@ export class MenuBar {
     _initLayout() {
 
         // Create Layout
-        this._el.button_zoomin = DOM.create('button', 'tl-menubar-button', this._el.container);
-        this._el.button_zoomout = DOM.create('button', 'tl-menubar-button', this._el.container);
-        this._el.button_forwardtoend = DOM.create('button', 'tl-menubar-button', this._el.container);
-        this._el.button_backtostart = DOM.create('button', 'tl-menubar-button', this._el.container);
+        this._el.button_zoomin = DOM.createButton('tl-menubar-button', this._el.container);
+        this._el.button_zoomout = DOM.createButton('tl-menubar-button', this._el.container);
+        this._el.button_forwardtoend = DOM.createButton('tl-menubar-button', this._el.container);
+        this._el.button_backtostart = DOM.createButton('tl-menubar-button', this._el.container);
 
         if (Browser.mobile) {
             this._el.container.setAttribute("ontouchstart", " ");


### PR DESCRIPTION
Without the `type="button"` attribute, buttons that are (indirectly) in a `form` [will default](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type) to submitting such a form. Explicitly setting the `type` via a separate function should avoid this behavior.