### PR TITLE
Improved  `timegroup-message` element contrast

### DIFF
--- a/src/less/Variables.less
+++ b/src/less/Variables.less
@@ -67,6 +67,8 @@
 @minor-ticks-line-color: 		@minor-ticks-color;
 @major-ticks-line-color: 		darken(@minor-ticks-line-color,10);
 
+@timegroup-message-color:       darken(@ui-background-color-darker,2);
+
 @brand-color: 					darken(@ui-background-color,15);
 
 @era-color-1: 					@color-theme-complement;

--- a/src/less/themes/contrast/Variables.less
+++ b/src/less/themes/contrast/Variables.less
@@ -52,13 +52,13 @@
 ================================================== */
 @ui-background-color:			darken(@color-background, 5);
 @ui-background-color-darker:	darken(@color-background, 10);
+
 @marker-color: 					darken(@ui-background-color,5);
 @marker-outline-color: 			darken(@ui-background-color,40);
 @marker-selected-text-color: 	@color-background;
 @marker-text-color: 			darken(@marker-color,50);
 @marker-dot-color: 				darken(@marker-color, 33);
 @marker-dot-hover-color: 		darken(@marker-dot-color, 33);
-
 @marker-color-menubar-button:	darken(@marker-color,47);
 
 @minor-ticks-color:				darken(@ui-background-color,49);
@@ -66,6 +66,8 @@
 
 @minor-ticks-line-color: 		@minor-ticks-color;
 @major-ticks-line-color: 		darken(@minor-ticks-line-color,10);
+
+@timegroup-message-color:       darken(@ui-background-color-darker,47);
 
 @brand-color: 					darken(@ui-background-color,49);
 

--- a/src/less/timenav/TL.TimeGroup.less
+++ b/src/less/timenav/TL.TimeGroup.less
@@ -22,8 +22,8 @@
 	
 	.tl-timegroup-message {
 		//z-index:6;
-		color:darken(@ui-background-color-darker,2);
-		text-shadow: @color-background 0px 2px 2px;
+		color: @timegroup-message-color;
+		text-shadow: @color-background 0 2px 2px;
 		margin-left:80px;
 		//background-color:@ui-background-color;
 		


### PR DESCRIPTION
During testing the grouping feature our QAs noticed that the group message doesn't look contrast enough against the background. Even when the "contrast" theme is chosen. I confirmed that, as dev tools reported a non-sufficient contrast ratio, lower than 4.5.
![image](https://github.com/NUKnightLab/TimelineJS3/assets/68850090/7441e674-1fb8-4477-a71d-6f27391b98ee)
![image](https://github.com/NUKnightLab/TimelineJS3/assets/68850090/b98f62e6-fffb-4dac-acc3-84441b5c297c) ![image](https://github.com/NUKnightLab/TimelineJS3/assets/68850090/12cf2587-bb59-48dc-ae8d-99fabf1da17b)

I addressed that issue by creating the `@timegroup-message-color` that would have different contrast levels for the "default" and the "contrast" themes.

Here're the examples of the group messages with the "contrast" theme:
![image](https://github.com/NUKnightLab/TimelineJS3/assets/68850090/4924a0c3-408e-4f90-80ed-d2d56258a8a9) 
![image](https://github.com/NUKnightLab/TimelineJS3/assets/68850090/f43a7f3a-2155-4871-af69-26eb853f44ba) ![image](https://github.com/NUKnightLab/TimelineJS3/assets/68850090/7bf54484-5792-4c97-b071-4e4bc4c87f62)
