### PR TITLE
add functionality fro prefers-reduced-motion to the timeline buttons

### DIFF
--- a/src/js/timeline/Timeline.js
+++ b/src/js/timeline/Timeline.js
@@ -462,6 +462,18 @@ class Timeline {
 
     }
 
+    //Check prefered-reduced-motion - Accessibility to reduce motion if enabled in Operationg System
+    reducedMotionEnabled() {
+        const isReduced = 
+            window.matchMedia(`(prefers-reduced-motion: reduce)`) === true ||
+            window.matchMedia(`(prefers-reduced-motion: reduce)`).matches ===
+                true
+        // Change duration for speed in which slides move
+        if(isReduced){
+            this._updateDisplay(this._timenav.options.height, true, 1);
+        }
+    }
+
     _initEvents() {
         // TimeNav Events
         this._timenav.on('change', this._onTimeNavChange, this);
@@ -555,10 +567,12 @@ class Timeline {
     }
 
     _onStorySliderNext(e) {
+        this.reducedMotionEnabled()
         this.fire("nav_next", e);
     }
 
     _onStorySliderPrevious(e) {
+        this.reducedMotionEnabled()
         this.fire("nav_previous", e);
     }
 


### PR DESCRIPTION
This PR is related to issue #861 and #860. Users can enable `prefer-reduced-motion` in their respective operation system(macOS or windows) and TimelineJS should pick up those changes and change the duration of the `slider` when navigating the timeline.
- Add checker for `prefer-reduced-motion` on the timeline prev and next button
- TODO: add checker on the timeline nav button press