### PR TITLE
Fix broken timeline when using [dir="rtl"]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Timeline uses `webpack` for bundling, and uses the `webpack-dev-server` as part 
 
 ### Building
 
-In order to "compile" TimelineJS for use in other contexts, after following the instructions above, run the command `npm run dist`. This will populate a directory, `dist/` in the rool of your checked-out repository, with the javascript and CSS necessary to self-host TimelineJS.
+In order to "compile" TimelineJS for use in other contexts, after following the instructions above, run the command `npm run dist`. This will populate a directory, `dist/` in the root of your checked-out repository, with the javascript and CSS necessary to self-host TimelineJS.
 
 
 ### Testing

--- a/src/js/slider/SlideNav.js
+++ b/src/js/slider/SlideNav.js
@@ -114,7 +114,7 @@ export class SlideNav {
 		this._el.title = DOM.create("div", "tl-slidenav-title", this._el.content_container);
 		this._el.description = DOM.create("div", "tl-slidenav-description", this._el.content_container);
 		
-		this._el.icon.innerHTML				= "&nbsp;"
+		// this._el.icon.innerHTML				= "&nbsp;"
 		
 		this._update();
 	}

--- a/src/less/Variables.less
+++ b/src/less/Variables.less
@@ -103,6 +103,8 @@
 @opacity-slide-nav-title:		15;
 @opacity-slide-nav-desc:		 0;
 @opacity-slide-nav-desc-hover:  50;
+@width-slide-nav:				100px;
+@margin-slide-nav:				10px;
 
 /* Animation
 ================================================== */

--- a/src/less/slider/TL.SlideNav.less
+++ b/src/less/slider/TL.SlideNav.less
@@ -20,7 +20,6 @@
 
     .tl-slidenav-content-container {
 		width:@width-slide-nav;
-		position:absolute;
 	}
 	.tl-slidenav-title, .tl-slidenav-description {
 		//width:100%;
@@ -103,7 +102,7 @@
 .tl-slidenav-next {
 	text-align: right;
 	margin-right:@margin-slide-nav;
-    right: @width-slide-nav;
+    right: 0;
 	.tl-slidenav-title, .tl-slidenav-description {
 		margin-left:20px;
 	}
@@ -116,6 +115,7 @@
 }
 .tl-slidenav-previous {
 	text-align: left;
+    left: 0;
 	margin-left:@margin-slide-nav;
 	.tl-slidenav-icon {
 		margin-left: 0px;
@@ -128,13 +128,9 @@
 // Fixes usage of browsers default setting of `direction: rtl`
 [dir="rtl"] {
 	.tl-slidenav-previous {
-		left: @width-slide-nav;
-		// due to the &nbsp, we need to tweak this margin
-		margin-left: -(@margin-slide-nav/2);
+		direction: ltr;
 	}
 	.tl-slidenav-next {
-		right: @margin-slide-nav;
-		margin-right: 0;
 		&:hover .tl-slidenav-icon {
 			margin-right: -4px;
 		}
@@ -178,7 +174,6 @@
 } 
 .tl-skinny {
 	.tl-slidenav-next {
-	    right: 32px;
 		.tl-slidenav-icon {
 			margin-left:32 - 24px;
 		}

--- a/src/less/slider/TL.SlideNav.less
+++ b/src/less/slider/TL.SlideNav.less
@@ -19,7 +19,7 @@
     font-weight: inherit;
 
     .tl-slidenav-content-container {
-		width:100px;
+		width:@width-slide-nav;
 		position:absolute;
 	}
 	.tl-slidenav-title, .tl-slidenav-description {
@@ -102,8 +102,8 @@
 
 .tl-slidenav-next {
 	text-align: right;
-	margin-right:10px;
-    right: 100px;
+	margin-right:@margin-slide-nav;
+    right: @width-slide-nav;
 	.tl-slidenav-title, .tl-slidenav-description {
 		margin-left:20px;
 	}
@@ -116,12 +116,28 @@
 }
 .tl-slidenav-previous {
 	text-align: left;
-	margin-left:10px;
+	margin-left:@margin-slide-nav;
 	.tl-slidenav-icon {
 		margin-left: 0px;
 	}
 	.tl-slidenav-icon:before {
 		content: "\e650";
+	}
+}
+
+// Fixes usage of browsers default setting of `direction: rtl`
+[dir="rtl"] {
+	.tl-slidenav-previous {
+		left: @width-slide-nav;
+		// due to the &nbsp, we need to tweak this margin
+		margin-left: -(@margin-slide-nav/2);
+	}
+	.tl-slidenav-next {
+		right: @margin-slide-nav;
+		margin-right: 0;
+		&:hover .tl-slidenav-icon {
+			margin-right: -4px;
+		}
 	}
 }
 

--- a/src/less/timenav/TL.TimeNav.less
+++ b/src/less/timenav/TL.TimeNav.less
@@ -12,6 +12,8 @@
 	//border-top: 1px solid #e3e3e3;
 	//box-shadow: inset 10px 10px 5px 0px rgba(0,0,0,0.75);
 	//.box-shadow(inset -7px 0px 7px rgba(0,0,0,.30));
+	// fixes use of [dir="rtl"]
+	direction: ltr;
 
 	.tl-timenav-line {
 		position: absolute;


### PR DESCRIPTION
When `dir="rtl"` is set on the `<html>` element, the slidenav (prev/next) and timenav (slider) break. This can be easily replicated when developing locally and simply adding this attribute to the "Bundled TimelineJS test page".

The following fixes are quite minor and non-intrusive:
* The css will only be applied when [dir="rtl"] is present on a parent element
* The slider is set to always use `direction: ltr`
   * Using the above solution is the simplest solution, due to the absolute positioning logic which might bet too complicated if modified for this case
   * I have not found any regressions in the display of slider elements, even when using the `tl-rtl` class (they continue to display properly for rtl languages)

I have added a few less variables, as I found the hard-coded values to be a potential problem (for slide-nav width/margin).

Cheers!