### PR TITLE
Updates to pt-BR locale file and styling

### DIFF
--- a/src/js/language/locale/pt-br.json
+++ b/src/js/language/locale/pt-br.json
@@ -48,6 +48,16 @@
             "Dezembro"
         ]
     },
+    "era_labels": {
+        "positive_year": {
+            "prefix": "",
+            "suffix": ""
+        },
+        "negative_year": {
+            "prefix": "",
+            "suffix": "a.C"
+        }
+    },
     "api": {
         "wikipedia": "pt"
     },

--- a/src/js/language/locale/pt-br.json
+++ b/src/js/language/locale/pt-br.json
@@ -66,7 +66,8 @@
         "return_to_title": "Voltar para o título",
         "wikipedia": "Wikipédia, A enciclopédia livre",
         "loading_content": "Carregando Conteúdo",
-        "loading_timeline": "Carregando Timeline... "
+        "loading_timeline": "Carregando Timeline... ",
+        "swipe_to_navigate": "Arraste para navegar<br><span class='tl-button'>OK</span>"
     },
     "dateformats": {
         "time": "H:MM:ss' 'd mmmm',' yyyy''",

--- a/src/less/fonts/_font.base.less
+++ b/src/less/fonts/_font.base.less
@@ -76,7 +76,6 @@
 		.tl-timeaxis {
 			font-family: @font-navigation;
 			font-weight:@font-headings-weight;
-			text-transform: @font-headings-text-transform;
 		}
 	}
 	


### PR DESCRIPTION
Hi,

I added some information to the pt-BR locale file. One of them is the translation of "BCE" - in Portuguese, we use the abbreviation "a.C." (antes de Cristo).

I also modified the style file because it was forcing abbreviations to appear in uppercase. However, in pt-BR, by convention, we use lowercase for the first letter (e.g., "a.C." instead of "A.C."). I removed the declaration, as I believe whoever sets the same value for other languages will ensure the abbreviation follows their respective conventions.